### PR TITLE
v1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,36 @@
 All notable changes to this project will be documented in this file.
 See [our coding standards][commit-messages] for commit guidelines.
 
+## 1.13.0 (2023-02-25)
+
+
+### Features
+
+* Add support for livestreams ([9a4710b](https://github.com/guaclive/videojs-chromecast/commit/9a4710b3dcc7afa0ec16dabe4893d6d302d9abe6))
+* added tracks support, added session restoring support ([157b067](https://github.com/guaclive/videojs-chromecast/commit/157b067da97e2b3dcff8adc61666d3c5bd899cb2)), closes [/github.com/silvermine/videojs-chromecast/pull/89#pullrequestreview-645475948](https://github.com/guaclive//github.com/silvermine/videojs-chromecast/pull/89/issues/pullrequestreview-645475948)
+* Allow modifying the load request ([85fc983](https://github.com/guaclive/videojs-chromecast/commit/85fc983acfa8ed961166879630b4d372b5f1c00b))
+* customizable content URL ([f7f8437](https://github.com/guaclive/videojs-chromecast/commit/f7f84379ef75cfa1553b112b5e2782458a218861))
+
+
+### Bug Fixes
+
+* clean event listeners on player.dispose() ([#97](https://github.com/guaclive/videojs-chromecast/issues/97)) ([328c141](https://github.com/guaclive/videojs-chromecast/commit/328c141f4cf3ce65492b6beb511b0592585aefcd))
+* correctly fire ended event ([fbcda9b](https://github.com/guaclive/videojs-chromecast/commit/fbcda9bee7774d1d62236d59c34ecb8f1d8cdf1e))
+* downgrade class.extend to avoid unsafe-eval ([#52](https://github.com/guaclive/videojs-chromecast/issues/52)) ([4aaec89](https://github.com/guaclive/videojs-chromecast/commit/4aaec8900a865cb19f6e7df51a507b12bb6a48d7))
+* error because tech.seeking was not defined ([3bb0698](https://github.com/guaclive/videojs-chromecast/commit/3bb06984edee57997436ac89f714274779d11731))
+* missing `preload` function ([#30](https://github.com/guaclive/videojs-chromecast/issues/30)) ([c1bda1b](https://github.com/guaclive/videojs-chromecast/commit/c1bda1b59d93958f5b51fc3f857cdabf70e03a3e))
+* remove deprecated `.extend` method ([708bdbd](https://github.com/guaclive/videojs-chromecast/commit/708bdbd23526aa041d784c63af3aadc0b769004e)), closes [#152](https://github.com/guaclive/videojs-chromecast/issues/152) [#147](https://github.com/guaclive/videojs-chromecast/issues/147)
+* scrubbing workaround ([4cbf71f](https://github.com/guaclive/videojs-chromecast/commit/4cbf71f0a05958df2a8f8d95540350caac1b15e7))
+* scss deprecation warning ([e345639](https://github.com/guaclive/videojs-chromecast/commit/e34563986162b66955a0ce8147387755f49e40b3))
+* typo ([4124a0c](https://github.com/guaclive/videojs-chromecast/commit/4124a0c3b691aa5062825bd6cb88892212caa882))
+* update package name ([ef678bb](https://github.com/guaclive/videojs-chromecast/commit/ef678bb40eaf0b0af504df5bc184c6eae048619f))
+
+
+### Reverts
+
+* Revert "1.12.0" ([53258b3](https://github.com/guaclive/videojs-chromecast/commit/53258b34f8c9c35c814c0c06a5cf655f38f9f323))
+
+
 ## 1.13.0 (2022-09-21)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "sinon": "2.3.5"
       },
       "peerDependencies": {
-        "video.js": ">= 6 < 8"
+        "video.js": ">= 6 < 9"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
     "sinon": "2.3.5"
   },
   "peerDependencies": {
-    "video.js": ">= 6 < 8"
+    "video.js": ">= 6 < 9"
   }
 }

--- a/src/js/components/ChromecastButton.js
+++ b/src/js/components/ChromecastButton.js
@@ -1,156 +1,196 @@
-/**
- * The ChromecastButton module contains both the ChromecastButton class definition and
- * the function used to register the button as a Video.js Component.
- *
- * @module ChromecastButton
- */
+module.exports = function (videojs) {
+  /**
+   * Registers the ChromecastButton Component with Video.js. Calls
+   * {@link http://docs.videojs.com/Component.html#.registerComponent}, which will add a
+   * component called `chromecastButton` to the list of globally registered Video.js
+   * components. The `chromecastButton` is added to the player's control bar UI
+   * automatically once {@link module:enableChromecast} has been called. If you would
+   * like to specify the order of the buttons that appear in the control bar, including
+   * this button, you can do so in the options that you pass to the `videojs` function
+   * when creating a player:
+   *
+   * ```
+   * videojs('playerID', {
+   *    controlBar: {
+   *       children: [
+   *          'playToggle',
+   *          'progressControl',
+   *          'volumePanel',
+   *          'fullscreenToggle',
+   *          'chromecastButton',
+   *       ],
+   *    }
+   * });
+   * ```
+   *
+   * @param videojs {object} A reference to {@link http://docs.videojs.com/module-videojs.html|Video.js}
+   * @see http://docs.videojs.com/module-videojs.html#~registerPlugin
+   */
 
-var ChromecastButton;
+  /**
+   * The Video.js Button class is the base class for UI button components.
+   *
+   * @external Button
+   * @see {@link http://docs.videojs.com/Button.html|Button}
+   */
+  const ButtonComponent = videojs.getComponent("Button");
 
-/**
-* The Video.js Button class is the base class for UI button components.
-*
-* @external Button
-* @see {@link http://docs.videojs.com/Button.html|Button}
-*/
+  /**
+   * The ChromecastButton module contains both the ChromecastButton class definition and
+   * the function used to register the button as a Video.js Component.
+   * @module ChromecastButton
+   */
 
-/** @lends ChromecastButton.prototype */
-ChromecastButton = {
+  /** @lends ChromecastButton.prototype **/
+  class ChromecastButton extends ButtonComponent {
+    /**
+     * This class is a button component designed to be displayed in the
+     * player UI's control bar. It opens the Chromecast menu when clicked.
+     *
+     * @constructs
+     * @extends external:Button
+     * @param player {Player} the video.js player instance
+     */
+    constructor(player, options) {
+      super(player, options);
 
-   /**
-    * This class is a button component designed to be displayed in the player UI's control
-    * bar. It opens the Chromecast menu when clicked.
-    *
-    * @constructs
-    * @extends external:Button
-    * @param player {Player} the video.js player instance
-    */
-   constructor: function(player) {
-      this.constructor.super_.apply(this, arguments);
-
-      player.on('chromecastConnected', this._onChromecastConnected.bind(this));
-      player.on('chromecastDisconnected', this._onChromecastDisconnected.bind(this));
-      player.on('chromecastDevicesAvailable', this._onChromecastDevicesAvailable.bind(this));
-      player.on('chromecastDevicesUnavailable', this._onChromecastDevicesUnavailable.bind(this));
-
-      this.controlText('Open Chromecast menu');
+      player.on("chromecastConnected", this._onChromecastConnected.bind(this));
+      player.on(
+        "chromecastDisconnected",
+        this._onChromecastDisconnected.bind(this)
+      );
+      player.on(
+        "chromecastDevicesAvailable",
+        this._onChromecastDevicesAvailable.bind(this)
+      );
+      player.on(
+        "chromecastDevicesUnavailable",
+        this._onChromecastDevicesUnavailable.bind(this)
+      );
 
       // Use the initial state of `hasAvailableDevices` to call the corresponding event
       // handlers because the corresponding events may have already been emitted before
       // binding the listeners above.
-      if (player.chromecastSessionManager && player.chromecastSessionManager.hasAvailableDevices()) {
-         this._onChromecastDevicesAvailable();
+      if (
+        player.chromecastSessionManager &&
+        player.chromecastSessionManager.hasAvailableDevices()
+      ) {
+        this._onChromecastDevicesAvailable();
       } else {
-         this._onChromecastDevicesUnavailable();
+        this._onChromecastDevicesUnavailable();
       }
-   },
 
-   /**
-    * Overrides Button#buildCSSClass to return the classes used on the button element.
-    *
-    * @param el {DOMElement}
-    * @see {@link http://docs.videojs.com/Button.html#buildCSSClass|Button#buildCSSClass}
-    */
-   buildCSSClass: function() {
-      return 'vjs-chromecast-button ' + (this._isChromecastConnected ? 'vjs-chromecast-casting-state ' : '') +
-         this.constructor.super_.prototype.buildCSSClass();
-   },
+      if (options.addCastLabelToButton) {
+        this.el().classList.add("vjs-chromecast-button-lg");
 
-   /**
-    * Overrides Button#handleClick to handle button click events. Chromecast functionality
-    * is handled outside of this class, which should be limited to UI related logic. This
-    * function simply triggers an event on the player.
-    *
-    * @fires ChromecastButton#chromecastRequested
-    * @param el {DOMElement}
-    * @see {@link http://docs.videojs.com/Button.html#handleClick|Button#handleClick}
-    */
-   handleClick: function() {
-      this.player().trigger('chromecastRequested');
-   },
+        this._labelEl = document.createElement("span");
+        this._labelEl.classList.add("vjs-chromecast-button-label");
+        this._updateCastLabelText();
 
-   /**
-    * Handles `chromecastConnected` player events.
-    *
-    * @private
-    */
-   _onChromecastConnected: function() {
+        this.el().appendChild(this._labelEl);
+      } else {
+        this.controlText("Open Chromecast menu");
+      }
+    }
+
+    /**
+     * Overrides Button#buildCSSClass to return the classes used on the button element.
+     *
+     * @param el {DOMElement}
+     * @see {@link http://docs.videojs.com/Button.html#buildCSSClass|Button#buildCSSClass}
+     */
+    buildCSSClass() {
+      return (
+        "vjs-chromecast-button " +
+        (this._isChromecastConnected ? "vjs-chromecast-casting-state " : "") +
+        (this.options_.addCastLabelToButton
+          ? "vjs-chromecast-button-lg "
+          : "") +
+        ButtonComponent.prototype.buildCSSClass()
+      );
+    }
+
+    /**
+     * Overrides Button#handleClick to handle button click events. Chromecast
+     * functionality is handled outside of this class, which should be limited
+     * to UI related logic.  This function simply triggers an event on the player.
+     *
+     * @fires ChromecastButton#chromecastRequested
+     * @param el {DOMElement}
+     * @see {@link http://docs.videojs.com/Button.html#handleClick|Button#handleClick}
+     */
+    handleClick() {
+      this.player().trigger("chromecastRequested");
+    }
+
+    /**
+     * Handles `chromecastConnected` player events.
+     *
+     * @private
+     */
+    _onChromecastConnected() {
       this._isChromecastConnected = true;
       this._reloadCSSClasses();
-   },
+      this._updateCastLabelText();
+    }
 
-   /**
-    * Handles `chromecastDisconnected` player events.
-    *
-    * @private
-    */
-   _onChromecastDisconnected: function() {
+    /**
+     * Handles `chromecastDisconnected` player events.
+     *
+     * @private
+     */
+    _onChromecastDisconnected() {
       this._isChromecastConnected = false;
       this._reloadCSSClasses();
-   },
+      this._updateCastLabelText();
+    }
 
-   /**
-    * Handles `chromecastDevicesAvailable` player events.
-    *
-    * @private
-    */
-   _onChromecastDevicesAvailable: function() {
+    /**
+     * Handles `chromecastDevicesAvailable` player events.
+     *
+     * @private
+     */
+    _onChromecastDevicesAvailable() {
       this.show();
-   },
+    }
 
-   /**
-    * Handles `chromecastDevicesUnavailable` player events.
-    *
-    * @private
-    */
-   _onChromecastDevicesUnavailable: function() {
+    /**
+     * Handles `chromecastDevicesUnavailable` player events.
+     *
+     * @private
+     */
+    _onChromecastDevicesUnavailable() {
       this.hide();
-   },
+    }
 
-   /**
-    * Re-calculates which CSS classes the button needs and sets them on the buttons'
-    * DOMElement.
-    *
-    * @private
-    */
-   _reloadCSSClasses: function() {
+    /**
+     * Re-calculates which CSS classes the button needs and sets them on the buttons'
+     * DOMElement.
+     *
+     * @private
+     */
+    _reloadCSSClasses() {
       if (!this.el_) {
-         return;
+        return;
       }
       this.el_.className = this.buildCSSClass();
-   },
-};
+    }
 
-/**
- * Registers the ChromecastButton Component with Video.js. Calls
- * {@link http://docs.videojs.com/Component.html#.registerComponent}, which will add a
- * component called `chromecastButton` to the list of globally registered Video.js
- * components. The `chromecastButton` is added to the player's control bar UI
- * automatically once {@link module:enableChromecast} has been called. If you would like
- * to specify the order of the buttons that appear in the control bar, including this
- * button, you can do so in the options that you pass to the `videojs` function when
- * creating a player:
- *
- * ```
- * videojs('playerID', {
- *    controlBar: {
- *       children: [
- *          'playToggle',
- *          'progressControl',
- *          'volumePanel',
- *          'fullscreenToggle',
- *          'chromecastButton',
- *       ],
- *    }
- * });
- * ```
- *
- * @param videojs {object} A reference to {@link http://docs.videojs.com/module-videojs.html|Video.js}
- * @see http://docs.videojs.com/module-videojs.html#~registerPlugin
- */
-module.exports = function(videojs) {
-   var ChromecastButtonImpl;
+    /**
+     * Updates the optional cast label text based on whether the chromecast is connected
+     * or disconnected.
+     *
+     * @private
+     */
+    _updateCastLabelText() {
+      if (!this._labelEl) {
+        return;
+      }
+      this._labelEl.textContent = this._isChromecastConnected
+        ? this.localize("Disconnect Cast")
+        : this.localize("Cast");
+    }
+  }
 
-   ChromecastButtonImpl = videojs.extend(videojs.getComponent('Button'), ChromecastButton);
-   videojs.registerComponent('chromecastButton', ChromecastButtonImpl);
+  videojs.registerComponent("chromecastButton", ChromecastButton);
 };

--- a/src/js/tech/ChromecastTech.js
+++ b/src/js/tech/ChromecastTech.js
@@ -18,7 +18,7 @@ var ChromecastSessionManager = require("../chromecast/ChromecastSessionManager")
 module.exports = function(videojs) {
    var Tech = videojs.getComponent('Tech'),
        SESSION_TIMEOUT = 10 * 1000; // milliseconds
- 
+
    /**
     * @module ChomecastTech
     */
@@ -495,7 +495,7 @@ module.exports = function(videojs) {
       this._remotePlayer.currentTime = Math.min(duration - 1, time);
       this._remotePlayerController.seek();
       this._isSeeking = false;
-   } 500);
+   }, 500);
     this._triggerTimeUpdateEvent();
   }
 

--- a/src/js/tech/ChromecastTech.js
+++ b/src/js/tech/ChromecastTech.js
@@ -1,974 +1,5 @@
-var ChromecastSessionManager = require('../chromecast/ChromecastSessionManager'),
-    ChromecastTechUI = require('./ChromecastTechUI'),
-    SESSION_TIMEOUT = 10 * 1000, // milliseconds
-    ChromecastTech;
-
-/**
- * @module ChromecastTech
- */
-
-/**
- * The Video.js Tech class is the base class for classes that provide media playback
- * technology implementations to Video.js such as HTML5, Flash and HLS.
- *
- * @external Tech
- * @see {@link http://docs.videojs.com/Tech.html|Tech}
- */
-
-/** @lends ChromecastTech.prototype */
-ChromecastTech = {
-
-   /**
-    * Implements Video.js playback {@link http://docs.videojs.com/tutorial-tech_.html|Tech}
-    * for {@link https://developers.google.com/cast/|Google's Chromecast}.
-    *
-    * @constructs ChromecastTech
-    * @extends external:Tech
-    * @param options {object} The options to use for configuration
-    * @see {@link https://developers.google.com/cast/|Google Cast}
-    */
-   constructor: function(options) {
-      var mediaSession,
-          textTrackDisplay,
-          subclass;
-
-      this._eventListeners = [];
-      this.options = options;
-      this.videojsPlayer = this.videojs(options.playerId);
-      this._chromecastSessionManager = this.videojsPlayer.chromecastSessionManager;
-
-      // We have to initialize the UI here, before calling super.constructor
-      // because the constructor calls `createEl`, which references `this._ui`.
-      this._ui = new ChromecastTechUI();
-      this._ui.updatePoster(this.videojsPlayer.poster());
-
-      // Call the super class' constructor function
-      subclass = this.constructor.super_.apply(this, arguments);
-
-      this._remotePlayer = this._chromecastSessionManager.getRemotePlayer();
-      this._remotePlayerController = this._chromecastSessionManager.getRemotePlayerController();
-      this._listenToPlayerControllerEvents();
-      this.on('dispose', this._onDispose.bind(this));
-
-      this._hasPlayedAnyItem = false;
-      this._onChangeSubtitleTrack = options.onChangeSubtitleTrackFn || function() { /* noop */ };
-      this._requestTitle = options.requestTitleFn || function() { /* noop */ };
-      this._requestSubtitle = options.requestSubtitleFn || function() { /* noop */ };
-      this._requestQueueItemChange = options.requestQueueItemChangeFn || function() { /* noop */ };
-      this._requestCustomData = options.requestCustomDataFn || function() { /* noop */ };
-      this._modifyLoadRequestFn = options.modifyLoadRequestFn || function() { /* noop */ };
-      this._requestLoadSource = options.requestLoadSourceFn || function(source) {
-         return source;
-      };
-      const loadSource = this._requestLoadSource(options.source);
-
-      // See `currentTime` function
-      this._initialStartTime = options.startTime === undefined ? (loadSource.startTime || 0) : options.startTime;
-      this._isScrubbing = false;
-      this._isSeeking = false;
-      this._scrubbingTime = this._initialStartTime;
-
-      mediaSession = this._getMediaSession();
-      if (mediaSession && mediaSession.media && mediaSession.media.entity === loadSource.entity) {
-         this.onLoadSessionSuccess();
-      } else {
-         this._playSource(options.source);
-      }
-
-      this.ready(function() {
-         this.setMuted(options.muted);
-      }.bind(this));
-      this.videojsPlayer.remoteTextTracks().on('change', this._onChangeTrack.bind(this));
-      textTrackDisplay = this.videojsPlayer.getChild('TextTrackDisplay');
-
-      if (textTrackDisplay) {
-         textTrackDisplay.hide();
-      }
-
-      return subclass;
-   },
-
-   /**
-    * Creates a DOMElement that Video.js displays in its player UI while this Tech is
-    * active.
-    *
-    * @returns {DOMElement}
-    * @see {@link http://docs.videojs.com/Tech.html#createEl}
-    */
-   createEl: function() {
-      return this._ui.getDOMElement();
-   },
-
-   /**
-    * Resumes playback if a media item is paused or restarts an item from its beginning if
-    * the item has played and ended.
-    *
-    * @see {@link http://docs.videojs.com/Player.html#play}
-    */
-   play: function() {
-      if (!this.paused()) {
-         return;
-      }
-      if (this.ended()) {
-         // Restart the current item from the beginning
-         this._playSource(this.videojsPlayer.currentSource(), 0);
-      } else {
-         this._remotePlayerController.playOrPause();
-      }
-   },
-
-   /**
-    * Pauses playback if the player is not already paused and if the current media item
-    * has not ended yet.
-    *
-    * @see {@link http://docs.videojs.com/Player.html#pause}
-    */
-   pause: function() {
-      if (!this.paused() && this._remotePlayer.canPause) {
-         this._remotePlayerController.playOrPause();
-      }
-   },
-
-   /**
-    * Returns whether or not the player is "paused". Video.js' definition of "paused" is
-    * "playback paused" OR "not playing".
-    *
-    * @returns {boolean} true if playback is paused
-    * @see {@link http://docs.videojs.com/Player.html#paused}
-    */
-   paused: function() {
-      return this._remotePlayer.isPaused || this.ended() || this._remotePlayer.playerState === null;
-   },
-
-   /**
-    * Stores the given source and begins playback, starting at the beginning
-    * of the media item.
-    *
-    * @param source {object} the source to store and play
-    * @see {@link http://docs.videojs.com/Player.html#src}
-    */
-   setSource: function(source) {
-      const mediaSession = this._getMediaSession();
-
-      if (source.entity && mediaSession && mediaSession.media && mediaSession.media.entity === source.entity) {
-         // Skip setting the source if the `source` argument is the same as what's already
-         // been set. This `setSource` function calls `this._playSource` which sends a
-         // "load media" request to the Chromecast PlayerController. Because this function
-         // may be called multiple times in rapid succession with the same `source`
-         // argument, we need to de-duplicate calls with the same `source` argument to
-         // prevent overwhelming the Chromecast PlayerController with expensive "load
-         // media" requests, which it itself does not de-duplicate.
-         return;
-      }
-
-      this._playSource(source);
-   },
-
-   /**
-    * Generate `chrome.cast.media.Track` instance from `trackData`
-    *
-    * @param trackData {Object}
-    * @param trackData.src
-    * @param trackData.kind
-    * @param trackData.language
-    * @param id
-    * @returns {chrome.cast.media.Track}
-    * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.Track
-    */
-   generateTrack: function(trackData, id) {
-      var sub = new chrome.cast.media.Track(id, chrome.cast.media.TrackType.TEXT),
-          textTrackTypes;
-
-      textTrackTypes = {
-         subtitles: chrome.cast.media.TextTrackType.SUBTITLES,
-         captions: chrome.cast.media.TextTrackType.CAPTIONS,
-         descriptions: chrome.cast.media.TextTrackType.DESCRIPTIONS,
-         chapters: chrome.cast.media.TextTrackType.CHAPTERS,
-         metadata: chrome.cast.media.TextTrackType.METADATA,
-      };
-
-      sub.trackContentId = trackData.src;
-      sub.subtype = textTrackTypes[trackData.kind];
-      sub.name = trackData.language;
-      sub.language = trackData.language;
-      return sub;
-   },
-
-   /**
-    * _onChangeTrack
-    * @private
-    */
-   _onChangeTrack: function() {
-      var castSession = cast.framework.CastContext.getInstance().getCurrentSession(),
-          media = castSession.getMediaSession(),
-          noop = function() { /* noop */ },
-          index, subtitles, tracksInfoRequest, i;
-
-      // TODO: investigate the case when we're trying to change track while there's no `media` (yet?)
-      if (castSession && media) {
-         index = [];
-         subtitles = this.videojsPlayer.remoteTextTracks();
-         for (i = 0; i < subtitles.length; i++) {
-            if (subtitles[i].mode === 'showing') {
-               index = [ i ];
-            }
-         }
-         tracksInfoRequest = new chrome.cast.media.EditTracksInfoRequest(index);
-
-         media.editTracksInfo(tracksInfoRequest, noop, noop);
-      }
-   },
-
-   /**
-    * Plays the given source, beginning at an optional starting time.
-    *
-    * @private
-    * @param source {object} the source to play
-    * @param [startTime] The time to start playback at, in seconds
-    * @see {@link http://docs.videojs.com/Player.html#src}
-    */
-   _playSource: function(source, startTime) {
-
-      var castSession = this._getCastSession(),
-          loadSource = this._requestLoadSource(source),
-          mediaInfo = new chrome.cast.media.MediaInfo(loadSource.src, loadSource.type),
-          title = this._requestTitle(source),
-          subtitle = this._requestSubtitle(source),
-          customData = this._requestCustomData(source),
-          textTrackJsonTracks = this.videojsPlayer.textTracksJson_,
-          request,
-          castSessionObj,
-          i;
-
-      this.trigger('waiting');
-      this._clearSessionTimeout();
-
-      // if more then one source was load, load queue
-      if (loadSource.sources) {
-         this._queue = loadSource.sources;
-         const queueMediaInfo = loadSource.sources.map((queueItem) => {
-            const mediaInfoItem = new chrome.cast.media.MediaInfo(queueItem.src, queueItem.type);
-
-            mediaInfoItem.entity = queueItem.entity;
-
-            mediaInfoItem.contentUrl = queueItem.src;
-            mediaInfoItem.metadata = new chrome.cast.media.GenericMediaMetadata();
-            mediaInfoItem.metadata.title = queueItem.title;
-            mediaInfoItem.duration = queueItem.duration;
-            mediaInfoItem.metadata.subtitle = queueItem.subtitle;
-            mediaInfoItem.streamType = this.videojsPlayer.liveTracker && this.videojsPlayer.liveTracker.isLive()
-               ? chrome.cast.media.StreamType.LIVE
-               : chrome.cast.media.StreamType.BUFFERED;
-            mediaInfoItem.tracks = [];
-            mediaInfoItem.activeTrackIds = [];
-            return new chrome.cast.media.QueueItem(mediaInfoItem);
-         });
-
-         request = new chrome.cast.media.LoadRequest();
-         request.startIndex = loadSource.startIndex;
-         request.queueData = new chrome.cast.media.QueueData(undefined, undefined, undefined, undefined, queueMediaInfo, loadSource.startIndex, loadSource.startTime);
-      } else {
-         this._queue = null;
-         mediaInfo.entity = loadSource.entity;
-         mediaInfo.contentUrl = loadSource.src;
-         mediaInfo.contentType = loadSource.type;
-
-         mediaInfo.metadata = new chrome.cast.media.GenericMediaMetadata();
-         mediaInfo.metadata.metadataType = chrome.cast.media.MetadataType.GENERIC;
-         mediaInfo.metadata.title = title;
-         mediaInfo.metadata.subtitle = subtitle;
-         mediaInfo.streamType = this.videojsPlayer.liveTracker && this.videojsPlayer.liveTracker.isLive()
-            ? chrome.cast.media.StreamType.LIVE
-            : chrome.cast.media.StreamType.BUFFERED;
-         mediaInfo.tracks = [];
-         mediaInfo.activeTrackIds = [];
-
-         for (i = 0; i < textTrackJsonTracks.length; i++) {
-            mediaInfo.tracks.push(this.generateTrack(textTrackJsonTracks[i], i));
-            if (textTrackJsonTracks[i].mode === 'showing') {
-               mediaInfo.activeTrackIds.push(i);
-            }
-         }
-
-         if (customData) {
-            mediaInfo.customData = customData;
-         }
-         request = new chrome.cast.media.LoadRequest(mediaInfo);
-      }
-
-      request.autoplay = true;
-      request.currentTime = startTime === undefined ? loadSource.startTime : startTime;
-      request.customData = this._requestCustomData();
-      if (loadSource.credentials) {
-         const credentialsData = new chrome.cast.CredentialsData(loadSource.credentials);
-
-         request = { ...request, ...credentialsData };
-      }
-      request = this._modifyLoadRequestFn(request);
-
-      this._isMediaLoading = true;
-      this._hasPlayedCurrentItem = false;
-      this._ui.updateTitle(title);
-      this._ui.updateSubtitle(subtitle);
-      castSessionObj = castSession.getSessionObj();
-      castSessionObj.loadMedia(request, this.onLoadSessionSuccess.bind(this), this._triggerErrorEvent.bind(this));
-   },
-
-   /**
-    * onLoadSessionSuccess
-    */
-   onLoadSessionSuccess: function() {
-      if (!this._hasPlayedAnyItem) {
-         // `triggerReady` is required here to notify the Video.js player that the
-         // Tech has been initialized and is ready.
-         this.triggerReady();
-      }
-
-      this.trigger('loadstart');
-      this.trigger('loadeddata');
-      this.trigger('play');
-      this.trigger('playing');
-      this.videojsPlayer.hasStarted(true);
-      this._hasPlayedAnyItem = true;
-      this._isMediaLoading = false;
-      clearTimeout(this.playStateValidationTimeout);
-      this.playStateValidationTimeout = window.setTimeout(this.validatePlayState.bind(this), 1000);
-      this._getMediaSession().addUpdateListener(this._onMediaSessionStatusChanged.bind(this));
-   },
-
-   /**
-    * Validate play state to make sure Chromecast and local player are in sync.
-    */
-   validatePlayState: function() {
-      var textTrackDisplay = this.videojsPlayer.getChild('TextTrackDisplay');
-
-      this._triggerTimeUpdateEvent();
-      this._onPlayerStateChanged();
-      this._onChangeTrack();
-
-      if (textTrackDisplay) {
-         textTrackDisplay.hide();
-      }
-   },
-
-   /**
-    * Manually updates the current time. The playback position will jump to the given time
-    * and continue playing if the item was playing when `setCurrentTime` was called, or
-    * remain paused if the item was paused.
-    *
-    * @param time {number} the playback time position to jump to
-    * @see {@link http://docs.videojs.com/Tech.html#setCurrentTime}
-    */
-   setCurrentTime: function(time) {
-      if (this.scrubbing()) {
-         this._scrubbingTime = time;
-         return false;
-      }
-      const duration = this.duration();
-
-      if (time > duration || !this._remotePlayer.canSeek) {
-         return;
-      }
-
-      // We need to delay the actual seeking, because when you
-      // scrub, videojs does pause() -> setCurrentTime() -> play()
-      // and that triggers a weird bug where the chromecast stops sending
-      // time_changed events.
-      this._isSeeking = true;
-      setTimeout(() => {
-         // Seeking to any place within (approximately) 1 second of the end of the item
-         // causes the Video.js player to get stuck in a BUFFERING state. To work around
-         // this, we only allow seeking to within 1 second of the end of an item.
-         this._remotePlayer.currentTime = Math.min(duration - 1, time);
-         this._remotePlayerController.seek();
-         this._isSeeking = false;
-      }, 500);
-      this._triggerTimeUpdateEvent();
-   },
-
-   seeking: function() {
-      return this._isSeeking;
-   },
-
-   scrubbing: function() {
-      return this._isScrubbing;
-   },
-
-   setScrubbing: function(newValue) {
-      if (newValue === true) {
-         this._scrubbingTime = this.currentTime();
-         this._isScrubbing = true;
-      } else {
-         this._isScrubbing = false;
-         this.setCurrentTime(this._scrubbingTime);
-      }
-   },
-
-   /**
-    * Returns the current playback time position.
-    *
-    * @returns {number} the current playback time position
-    * @see {@link http://docs.videojs.com/Player.html#currentTime}
-    */
-   currentTime: function() {
-      // There is a brief period of time when Video.js has switched to the chromecast
-      // Tech, but chromecast has not yet loaded its first media item. During that time,
-      // Video.js calls this `currentTime` function to update its player UI. In that
-      // period, `this._remotePlayer.currentTime` will be 0 because the media has not
-      // loaded yet. To prevent the UI from using a 0 second currentTime, we use the
-      // currentTime passed in to the first media item that was provided to the Tech until
-      // chromecast plays its first item.
-      if (!this._hasPlayedAnyItem) {
-         return this._initialStartTime;
-      }
-      if (this.scrubbing() || this.seeking()) {
-         return this._scrubbingTime;
-      }
-      return this._remotePlayer.currentTime;
-   },
-
-   /**
-    * Returns the duration of the current media item, or `0` if the source is not set or
-    * if the duration of the item is not available from the Chromecast API yet.
-    *
-    * @returns {number} the duration of the current media item
-    * @see {@link http://docs.videojs.com/Player.html#duration}
-    */
-   duration: function() {
-      // There is a brief period of time when Video.js has switched to the chromecast
-      // Tech, but chromecast has not yet loaded its first media item. During that time,
-      // Video.js calls this `duration` function to update its player UI. In that period,
-      // `this._remotePlayer.duration` will be 0 because the media has not loaded yet. To
-      // prevent the UI from using a 0 second duration, we use the duration passed in to
-      // the first media item that was provided to the Tech until chromecast plays its
-      // first item.
-      if (!this._hasPlayedAnyItem) {
-         return this.videojsPlayer.duration();
-      }
-      return this._remotePlayer.duration;
-   },
-
-   /**
-    * Returns whether or not the current media item has finished playing. Returns `false`
-    * if a media item has not been loaded, has not been played, or has not yet finished
-    * playing.
-    *
-    * @returns {boolean} true if the current media item has finished playing
-    * @see {@link http://docs.videojs.com/Player.html#ended}
-    */
-   ended: function() {
-      var mediaSession = this._getMediaSession();
-
-      // Don't check for queues
-      // When handling a queue there are moments when mediaSession is null and current item has already finished
-      // and the new item is not started loading yet, which would end the session.
-      if (this._queue) {
-         return false;
-      }
-      if (!mediaSession && this._hasMediaSessionEnded && !this._isMediaLoading) {
-         return true;
-      }
-      return mediaSession ? (mediaSession.idleReason === chrome.cast.media.IdleReason.FINISHED) : false;
-   },
-
-   /**
-    * Returns the current volume level setting as a decimal number between `0` and `1`.
-    *
-    * @returns {number} the current volume level
-    * @see {@link http://docs.videojs.com/Player.html#volume}
-    */
-   volume: function() {
-      return this._remotePlayer.volumeLevel;
-   },
-
-   /**
-    * Sets the current volume level. Volume level is a decimal number between `0` and `1`,
-    * where `0` is muted and `1` is the loudest volume level.
-    *
-    * @param volumeLevel {number}
-    * @returns {number} the current volume level
-    * @see {@link http://docs.videojs.com/Player.html#volume}
-    */
-   setVolume: function(volumeLevel) {
-      this._remotePlayer.volumeLevel = volumeLevel;
-      this._remotePlayerController.setVolumeLevel();
-      // This event is triggered by the listener on
-      // `RemotePlayerEventType.VOLUME_LEVEL_CHANGED`, but waiting for that event to fire
-      // in response to calls to `setVolume` introduces noticeable lag in the updating of
-      // the player UI's volume slider bar, which makes user interaction with the volume
-      // slider choppy.
-      this._triggerVolumeChangeEvent();
-   },
-
-   /**
-    * Returns whether or not the player is currently muted.
-    *
-    * @returns {boolean} true if the player is currently muted
-    * @see {@link http://docs.videojs.com/Player.html#muted}
-    */
-   muted: function() {
-      return this._remotePlayer.isMuted;
-   },
-
-   /**
-    * Mutes or un-mutes the player. Does nothing if the player is currently muted and the
-    * `isMuted` parameter is true or if the player is not muted and `isMuted` is false.
-    *
-    * @param isMuted {boolean} whether or not the player should be muted
-    * @see {@link http://docs.videojs.com/Html5.html#setMuted} for an example
-    */
-   setMuted: function(isMuted) {
-      if ((this._remotePlayer.isMuted && !isMuted) || (!this._remotePlayer.isMuted && isMuted)) {
-         this._remotePlayerController.muteOrUnmute();
-      }
-   },
-
-   /**
-    * Gets the URL to the current poster image.
-    *
-    * @returns {string} URL to the current poster image or `undefined` if none exists
-    * @see {@link http://docs.videojs.com/Player.html#poster}
-    */
-   poster: function() {
-      return this._ui.getPoster();
-   },
-
-   /**
-    * Sets the URL to the current poster image. The poster image shown in the Chromecast
-    * Tech UI view is updated with this new URL.
-    *
-    * @param poster {string} the URL to the new poster image
-    * @see {@link http://docs.videojs.com/Tech.html#setPoster}
-    */
-   setPoster: function(poster) {
-      this._ui.updatePoster(poster);
-   },
-
-   /**
-    * This function is "required" when implementing {@link external:Tech} and is supposed
-    * to return a mock
-    * {@link https://developer.mozilla.org/en-US/docs/Web/API/TimeRanges|TimeRanges}
-    * object that represents the portions of the current media item that have been
-    * buffered. However, the Chromecast API does not currently provide a way to determine
-    * how much the media item has buffered, so we always return `undefined`.
-    *
-    * Returning `undefined` is safe: the player will simply not display the buffer amount
-    * indicator in the scrubber UI.
-    *
-    * @returns {undefined} always returns `undefined`
-    * @see {@link http://docs.videojs.com/Player.html#buffered}
-    */
-   buffered: function() {
-      return undefined;
-   },
-
-   /**
-    * This function is "required" when implementing {@link external:Tech} and is supposed
-    * to return a mock
-    * {@link https://developer.mozilla.org/en-US/docs/Web/API/TimeRanges|TimeRanges}
-    * object that represents the portions of the current media item that has playable
-    * content. However, the Chromecast API does not currently provide a way to determine
-    * how much the media item has playable content, so we'll just assume the entire video
-    * is an available seek target.
-    *
-    * The risk here lies with live streaming, where there may exist a sliding window of
-    * playable content and seeking is only possible within the last X number of minutes,
-    * rather than for the entire video.
-    *
-    * Unfortunately we have no way of detecting when this is the case. Returning anything
-    * other than the full range of the video means that we lose the ability to seek during
-    * VOD.
-    *
-    * @returns {TimeRanges} always returns a `TimeRanges` object with one `TimeRange` that
-    * starts at `0` and ends at the `duration` of the current media item
-    * @see {@link http://docs.videojs.com/Player.html#seekable}
-    */
-   seekable: function() {
-      // TODO Investigate if there's a way to detect if the source is live, so that we can
-      // possibly adjust the seekable `TimeRanges` accordingly.
-      return this.videojs.createTimeRange(0, this.duration());
-   },
-
-   /**
-    * Returns whether the native media controls should be shown (`true`) or hidden
-    * (`false`). Not applicable to this Tech.
-    *
-    * @returns {boolean} always returns `false`
-    * @see {@link http://docs.videojs.com/Html5.html#controls} for an example
-    */
-   controls: function() {
-      return false;
-   },
-
-   /**
-    * Returns whether or not the browser should show the player "inline" (non-fullscreen)
-    * by default. This function always returns true to tell the browser that non-
-    * fullscreen playback is preferred.
-    *
-    * @returns {boolean} always returns `true`
-    * @see {@link http://docs.videojs.com/Html5.html#playsinline} for an example
-    */
-   playsinline: function() {
-      return true;
-   },
-
-   /**
-    * Returns whether or not fullscreen is supported by this Tech. Always returns `true`
-    * because fullscreen is always supported.
-    *
-    * @returns {boolean} always returns `true`
-    * @see {@link http://docs.videojs.com/Html5.html#supportsFullScreen} for an example
-    */
-   supportsFullScreen: function() {
-      return true;
-   },
-
-   /**
-    * Sets a flag that determines whether or not the media should automatically begin
-    * playing on page load. This is not supported because a Chromecast session must be
-    * initiated by casting via the casting menu and cannot autoplay.
-    *
-    * @see {@link http://docs.videojs.com/Html5.html#setAutoplay} for an example
-    */
-   setAutoplay: function() {
-      // Not supported
-   },
-
-   /**
-    * @returns {number} the chromecast player's playback rate, if available. Otherwise,
-    * the return value defaults to `1`.
-    */
-   playbackRate: function() {
-      var mediaSession = this._getMediaSession();
-
-      return mediaSession ? mediaSession.playbackRate : 1;
-   },
-
-   /**
-    * Does nothing. Changing the playback rate is not supported.
-    */
-   setPlaybackRate: function() {
-      // Not supported
-   },
-
-   /**
-    * Does nothing. Satisfies calls to the missing preload method.
-    */
-   preload: function() {
-      // Not supported
-   },
-
-   /**
-    * Causes the Tech to begin loading the current source. `load` is not supported in this
-    * ChromecastTech because setting the source on the `Chromecast` automatically causes
-    * it to begin loading.
-    */
-   load: function() {
-      // Not supported
-   },
-
-   /**
-    * Gets the Chromecast equivalent of HTML5 Media Element's `readyState`.
-    *
-    * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/readyState
-    */
-   readyState: function() {
-      if (this._remotePlayer.playerState === 'IDLE' || this._remotePlayer.playerState === 'BUFFERING') {
-         return 0; // HAVE_NOTHING
-      }
-      return 4;
-   },
-
-   /**
-    * Wires up event listeners for
-    * [RemotePlayerController](https://developers.google.com/cast/docs/reference/chrome/cast.framework.RemotePlayerController)
-    * events.
-    *
-    * @private
-    */
-   _listenToPlayerControllerEvents: function() {
-      var eventTypes = cast.framework.RemotePlayerEventType;
-
-      this._addEventListener(this._remotePlayerController, eventTypes.MEDIA_INFO_CHANGED, () => {
-         if (typeof this._getMediaSession().activeTrackIds[0] === 'number') {
-            const id = this._getMediaSession().activeTrackIds[0];
-
-            const tracks = this._getMediaSession().media.tracks;
-
-            const name = tracks[id].name;
-
-            this._onChangeSubtitleTrack({ name });
-         } else {
-            this._onChangeSubtitleTrack(null);
-         }
-      }, this);
-      this._addEventListener(this._remotePlayerController, eventTypes.PLAYER_STATE_CHANGED, this._onPlayerStateChanged, this);
-      this._addEventListener(this._remotePlayerController, eventTypes.VOLUME_LEVEL_CHANGED, this._triggerVolumeChangeEvent, this);
-      this._addEventListener(this._remotePlayerController, eventTypes.IS_MUTED_CHANGED, this._triggerVolumeChangeEvent, this);
-      this._addEventListener(this._remotePlayerController, eventTypes.CURRENT_TIME_CHANGED, this._triggerTimeUpdateEvent, this);
-      this._addEventListener(this._remotePlayerController, eventTypes.DURATION_CHANGED, this._triggerDurationChangeEvent, this);
-      // If any subtitles were loaded on cast receiver side,
-      // check if they exist on web player side, if not add them
-      this._addEventListener(this._remotePlayerController, eventTypes.MEDIA_INFO_CHANGED, (event) => {
-         this.videojsPlayer.remoteTextTracks();
-         const alreadyLoadedTracks = this.videojsPlayer.remoteTextTracks().tracks_;
-
-         const player = this.videojsPlayer;
-
-         if (event.value && event.value.tracks) {
-            event.value.tracks.forEach(function(track) {
-               const isAlreadyLoaded = alreadyLoadedTracks.some(function(alreadyLoadedTrack) {
-                  return alreadyLoadedTrack.id === track.name;
-               });
-
-               if (!isAlreadyLoaded) {
-                  track.id = track.name;
-                  player.addRemoteTextTrack(track);
-               }
-            });
-         }
-
-      });
-      this._addEventListener(this._remotePlayerController, eventTypes.MEDIA_INFO_CHANGED, this._handleMediaInfoChangeEvent, this);
-   },
-
-   /**
-    * Registers an event listener on the given target object. Because many objects in the
-    * Chromecast API are either singletons or must be shared between instances of
-    * `ChromecastTech` for the lifetime of the player, we must unbind the listeners when
-    * this Tech instance is destroyed to prevent memory leaks. To do that, we need to keep
-    * a reference to listeners that are added to global objects so that we can use those
-    * references to remove the listener when this Tech is destroyed.
-    *
-    * @param target {object} the object to register the event listener on
-    * @param type {string} the name of the event
-    * @param callback {Function} the listener's callback function that executes when the
-    * event is emitted
-    * @param context {object} the `this` context to use when executing the `callback`
-    * @private
-    */
-   _addEventListener: function(target, type, callback, context) {
-      var listener;
-
-      listener = {
-         target: target,
-         type: type,
-         callback: callback,
-         context: context,
-         listener: callback.bind(context),
-      };
-      target.addEventListener(type, listener.listener);
-      this._eventListeners.push(listener);
-   },
-
-   /**
-    * _onDispose
-    * @private
-    */
-   _onDispose: function() {
-      var textTrackDisplay = this.videojsPlayer.getChild('TextTrackDisplay');
-
-      if (textTrackDisplay) {
-         textTrackDisplay.show();
-      }
-      clearTimeout(this.playStateValidationTimeout);
-      this._removeAllEventListeners();
-      // even with `stopCasting === false`, `endCurrentSession` *stops* casting
-      // this._getCastContext().endCurrentSession(/* stopCasting */ false);
-   },
-
-   /**
-    * Removes all event listeners that were registered with global objects during the
-    * lifetime of this Tech. See {@link _addEventListener} for more information about why
-    * this is necessary.
-    *
-    * @private
-    */
-   _removeAllEventListeners: function() {
-      while (this._eventListeners.length > 0) {
-         this._removeEventListener(this._eventListeners[0]);
-      }
-      this._eventListeners = [];
-   },
-
-   /**
-    * Removes a single event listener that was registered with global objects during the
-    * lifetime of this Tech. See {@link _addEventListener} for more information about why
-    * this is necessary.
-    *
-    * @private
-    */
-   _removeEventListener: function(listener) {
-      var index = -1,
-          pass = false,
-          i;
-
-      listener.target.removeEventListener(listener.type, listener.listener);
-
-      for (i = 0; i < this._eventListeners.length; i++) {
-         pass = this._eventListeners[i].target === listener.target &&
-               this._eventListeners[i].type === listener.type &&
-               this._eventListeners[i].callback === listener.callback &&
-               this._eventListeners[i].context === listener.context;
-
-         if (pass) {
-            index = i;
-            break;
-         }
-      }
-
-      if (index !== -1) {
-         this._eventListeners.splice(index, 1);
-      }
-   },
-
-   /**
-    * Handles Chromecast player state change events. The player may "change state" when
-    * paused, played, buffering, etc.
-    *
-    * @private
-    */
-   _onPlayerStateChanged: function() {
-      var states = chrome.cast.media.PlayerState,
-          playerState = this._remotePlayer.playerState;
-
-      if (playerState === states.PLAYING) {
-         this._hasPlayedCurrentItem = true;
-         this.trigger('play');
-         this.trigger('playing');
-      } else if (playerState === states.PAUSED) {
-         this.trigger('pause');
-      } else if ((playerState === states.IDLE && this.ended()) || (playerState === null && this._hasPlayedCurrentItem)) {
-         this._hasPlayedCurrentItem = false;
-         this._closeSessionOnTimeout();
-         this.trigger('ended');
-         this._triggerTimeUpdateEvent();
-      } else if (playerState === states.BUFFERING) {
-         this.trigger('waiting');
-      }
-   },
-
-   /**
-    * Handles Chromecast MediaSession state change events. The only property sent to this
-    * event is whether the session is alive. This is useful for determining if an item has
-    * ended as the MediaSession will fire this event with `false` then be immediately
-    * destroyed. This means that we cannot trust `idleReason` to show whether an item has
-    * ended since we may no longer have access to the MediaSession.
-    *
-    * @private
-    */
-   _onMediaSessionStatusChanged: function(isAlive) {
-      this._hasMediaSessionEnded = !!isAlive;
-   },
-
-   /**
-    * Ends the session after a certain number of seconds of inactivity.
-    *
-    * If the Chromecast player is in the "IDLE" state after an item has ended, and no
-    * further items are queued up to play, the session is considered inactive. Once a
-    * period of time (currently 10 seconds) has elapsed with no activity, we manually end
-    * the session to prevent long periods of a blank Chromecast screen that is shown at
-    * the end of item playback.
-    *
-    * @private
-    */
-   _closeSessionOnTimeout: function() {
-      // Ensure that there's never more than one session timeout active
-      this._clearSessionTimeout();
-      this._sessionTimeoutID = setTimeout(function() {
-         var castSession = this._getCastSession();
-
-         if (castSession) {
-            castSession.endSession(true);
-         }
-         this._clearSessionTimeout();
-      }.bind(this), SESSION_TIMEOUT);
-   },
-
-   /**
-    * Stops the timeout that is waiting during a period of inactivity in order to close
-    * the session.
-    *
-    * @private
-    * @see _closeSessionOnTimeout
-    */
-   _clearSessionTimeout: function() {
-      if (this._sessionTimeoutID) {
-         clearTimeout(this._sessionTimeoutID);
-         this._sessionTimeoutID = false;
-      }
-   },
-
-   /**
-    * @private
-    * @return {object} the current CastContext, if one exists
-    */
-   _getCastContext: function() {
-      return this._chromecastSessionManager.getCastContext();
-   },
-
-   /**
-    * @private
-    * @return {object} the current CastSession, if one exists
-    */
-   _getCastSession: function() {
-      return this._getCastContext().getCurrentSession();
-   },
-
-   /**
-    * @private
-    * @return {object} the current MediaSession, if one exists
-    * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.Media
-    */
-   _getMediaSession: function() {
-      var castSession = this._getCastSession();
-
-      return castSession ? castSession.getMediaSession() : null;
-   },
-
-   /**
-    * Triggers a 'volumechange' event
-    * @private
-    * @see http://docs.videojs.com/Player.html#event:volumechange
-    */
-   _triggerVolumeChangeEvent: function() {
-      this.trigger('volumechange');
-   },
-
-   /**
-    * Triggers a 'timeupdate' event
-    * @private
-    * @see http://docs.videojs.com/Player.html#event:timeupdate
-    */
-   _triggerTimeUpdateEvent: function() {
-      this.trigger('timeupdate');
-   },
-
-   /**
-    * Triggers a 'durationchange' event
-    * @private
-    * @see http://docs.videojs.com/Player.html#event:durationchange
-    */
-   _triggerDurationChangeEvent: function() {
-      this.trigger('durationchange');
-   },
-
-   /**
-    * @private
-    */
-   _handleMediaInfoChangeEvent: function(event) {
-      this._requestQueueItemChange(event);
-   },
-
-   /**
-    * Triggers an 'error' event
-    * @private
-    * @see http://docs.videojs.com/Player.html#event:error
-    */
-   _triggerErrorEvent: function() {
-      this.trigger('error');
-   },
-};
+var ChromecastSessionManager = require("../chromecast/ChromecastSessionManager"),
+  ChromecastTechUI = require("./ChromecastTechUI");
 
 /**
  * Registers the ChromecastTech Tech with Video.js. Calls {@link
@@ -986,27 +17,1959 @@ ChromecastTech = {
  */
 module.exports = function(videojs) {
    var Tech = videojs.getComponent('Tech'),
-       ChromecastTechImpl;
+       SESSION_TIMEOUT = 10 * 1000; // milliseconds
+ 
+   /**
+    * @module ChomecastTech
+    */
 
-   ChromecastTechImpl = videojs.extend(Tech, ChromecastTech);
+   /**
+    * The Video.js Tech class is the base class for classes that provide media playback
+    * technology implementations to Video.js such as HTML5, Flash and HLS.
+    *
+    * @external Tech
+    * @see {@link http://docs.videojs.com/Tech.html|Tech}
+    */
 
-   // Required for Video.js Tech implementations.
-   // TODO Consider a more comprehensive check based on mimetype.
-   ChromecastTechImpl.canPlaySource = () => { return ChromecastSessionManager.isChromecastConnected(); };
-   ChromecastTechImpl.isSupported = () => { return ChromecastSessionManager.isChromecastConnected(); };
+   /** @lends ChromecastTech.prototype */
+   class ChromecastTech extends Tech {
 
-   ChromecastTechImpl.prototype.featuresVolumeControl = true;
-   ChromecastTechImpl.prototype.featuresPlaybackRate = false;
-   ChromecastTechImpl.prototype.movingMediaElementInDOM = false;
-   ChromecastTechImpl.prototype.featuresFullscreenResize = true;
-   ChromecastTechImpl.prototype.featuresTimeupdateEvents = true;
-   ChromecastTechImpl.prototype.featuresProgressEvents = false;
-   ChromecastTechImpl.prototype.featuresNativeTextTracks = true;
-   ChromecastTechImpl.prototype.featuresNativeAudioTracks = false;
-   ChromecastTechImpl.prototype.featuresNativeVideoTracks = false;
+      /**
+       * Implements Video.js playback {@link http://docs.videojs.com/tutorial-tech_.html|Tech}
+       * for {@link https://developers.google.com/cast/|Google's Chromecast}.
+       *
+       * @constructs ChromecastTech
+       * @extends external:Tech
+       * @param options {object} The options to use for configuration
+       * @see {@link https://developers.google.com/cast/|Google Cast}
+       */
+      constructor(options) {
+         super(options);
 
-   // Give ChromecastTech class instances a reference to videojs
-   ChromecastTechImpl.prototype.videojs = videojs;
+         this.featuresVolumeControl = true;
+         this.featuresPlaybackRate = false;
+         this.movingMediaElementInDOM = false;
+         this.featuresFullscreenResize = true;
+         this.featuresTimeupdateEvents = true;
+         this.featuresProgressEvents = false;
+         // Text tracks are not supported in this version
+         this.featuresNativeTextTracks = false;
+         this.featuresNativeAudioTracks = false;
+         this.featuresNativeVideoTracks = false;
+    var mediaSession, textTrackDisplay, subclass;
 
-   videojs.registerTech('chromecast', ChromecastTechImpl);
+
+         // Give ChromecastTech class instances a reference to videojs
+         this.videojs = videojs;
+         this._eventListeners = [];
+    this.options = options;
+    this.videojsPlayer = this.videojs(options.playerId);
+    this._chromecastSessionManager =
+      this.videojsPlayer.chromecastSessionManager;
+
+    // We have to initialize the UI here, before calling super.constructor
+    // because the constructor calls `createEl`, which references `this._ui`.
+    this._ui = new ChromecastTechUI();
+    this._ui.updatePoster(this.videojsPlayer.poster());
+
+    // Call the super class' constructor function
+    subclass = this.constructor.super_.apply(this, arguments);
+
+    this._remotePlayer = this._chromecastSessionManager.getRemotePlayer();
+    this._remotePlayerController =
+      this._chromecastSessionManager.getRemotePlayerController();
+    this._listenToPlayerControllerEvents();
+    this.on("dispose", this._onDispose.bind(this));
+
+    this._hasPlayedAnyItem = false;
+    this._onChangeSubtitleTrack =
+      options.onChangeSubtitleTrackFn ||
+      function () {
+        /* noop */
+      };
+    this._requestTitle =
+      options.requestTitleFn ||
+      function () {
+        /* noop */
+      };
+    this._requestSubtitle =
+      options.requestSubtitleFn ||
+      function () {
+        /* noop */
+      };
+    this._requestQueueItemChange =
+      options.requestQueueItemChangeFn ||
+      function () {
+        /* noop */
+      };
+    this._requestCustomData =
+      options.requestCustomDataFn ||
+      function () {
+        /* noop */
+      };
+    this._modifyLoadRequestFn =
+      options.modifyLoadRequestFn ||
+      function () {
+        /* noop */
+      };
+    this._requestLoadSource =
+      options.requestLoadSourceFn ||
+      function (source) {
+        return source;
+      };
+    const loadSource = this._requestLoadSource(options.source);
+
+    // See `currentTime` function
+    this._initialStartTime =
+      options.startTime === undefined
+        ? loadSource.startTime || 0
+        : options.startTime;
+    this._isScrubbing = false;
+    this._isSeeking = false;
+    this._scrubbingTime = this._initialStartTime;
+
+    mediaSession = this._getMediaSession();
+    if (
+      mediaSession &&
+      mediaSession.media &&
+      mediaSession.media.entity === loadSource.entity
+    ) {
+      this.onLoadSessionSuccess();
+    } else {
+      this._playSource(options.source);
+    }
+
+    this.ready(
+      function () {
+        this.setMuted(options.muted);
+      }.bind(this)
+    );
+    this.videojsPlayer
+      .remoteTextTracks()
+      .on("change", this._onChangeTrack.bind(this));
+    textTrackDisplay = this.videojsPlayer.getChild("TextTrackDisplay");
+
+    if (textTrackDisplay) {
+      textTrackDisplay.hide();
+    }
+
+   }
+  /**
+       * Creates a DOMElement that Video.js displays in its player UI while this Tech is
+       * active.
+       *
+       * @returns {DOMElement}
+       * @see {@link http://docs.videojs.com/Tech.html#createEl}
+       */
+  createEl() {
+   // We have to initialize the UI here, because the super.constructor
+   // calls `createEl`, which references `this._ui`.
+   this._ui = this._ui || new ChromecastTechUI();
+
+   return this._ui.getDOMElement();
+}
+  /**
+   * Resumes playback if a media item is paused or restarts an item from its beginning if
+   * the item has played and ended.
+   *
+   * @see {@link http://docs.videojs.com/Player.html#play}
+   */
+  play() {
+    if (!this.paused()) {
+      return;
+    }
+    if (this.ended()) {
+      // Restart the current item from the beginning
+      this._playSource(this.videojsPlayer.currentSource(), 0);
+    } else {
+      this._remotePlayerController.playOrPause();
+    }
+  }
+
+  /**
+   * Pauses playback if the player is not already paused and if the current media item
+   * has not ended yet.
+   *
+   * @see {@link http://docs.videojs.com/Player.html#pause}
+   */
+  pause() {
+    if (!this.paused() && this._remotePlayer.canPause) {
+      this._remotePlayerController.playOrPause();
+    }
+  }
+
+  /**
+   * Returns whether or not the player is "paused". Video.js' definition of "paused" is
+   * "playback paused" OR "not playing".
+   *
+   * @returns {boolean} true if playback is paused
+   * @see {@link http://docs.videojs.com/Player.html#paused}
+   */
+  paused() {
+    return (
+      this._remotePlayer.isPaused ||
+      this.ended() ||
+      this._remotePlayer.playerState === null
+    );
+  }
+
+  /**
+   * Stores the given source and begins playback, starting at the beginning
+   * of the media item.
+   *
+   * @param source {object} the source to store and play
+   * @see {@link http://docs.videojs.com/Player.html#src}
+   */
+  setSource(source) {
+    const mediaSession = this._getMediaSession();
+
+    if (
+      source.entity &&
+      mediaSession &&
+      mediaSession.media &&
+      mediaSession.media.entity === source.entity
+    ) {
+      // Skip setting the source if the `source` argument is the same as what's already
+      // been set. This `setSource` function calls `this._playSource` which sends a
+      // "load media" request to the Chromecast PlayerController. Because this function
+      // may be called multiple times in rapid succession with the same `source`
+      // argument, we need to de-duplicate calls with the same `source` argument to
+      // prevent overwhelming the Chromecast PlayerController with expensive "load
+      // media" requests, which it itself does not de-duplicate.
+      return;
+    }
+
+    this._playSource(source);
+  }
+
+  /**
+   * Generate `chrome.cast.media.Track` instance from `trackData`
+   *
+   * @param trackData {Object}
+   * @param trackData.src
+   * @param trackData.kind
+   * @param trackData.language
+   * @param id
+   * @returns {chrome.cast.media.Track}
+   * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.Track
+   */
+  generateTrack (trackData, id) {
+    var sub = new chrome.cast.media.Track(id, chrome.cast.media.TrackType.TEXT),
+      textTrackTypes;
+
+    textTrackTypes = {
+      subtitles: chrome.cast.media.TextTrackType.SUBTITLES,
+      captions: chrome.cast.media.TextTrackType.CAPTIONS,
+      descriptions: chrome.cast.media.TextTrackType.DESCRIPTIONS,
+      chapters: chrome.cast.media.TextTrackType.CHAPTERS,
+      metadata: chrome.cast.media.TextTrackType.METADATA,
+    };
+
+    sub.trackContentId = trackData.src;
+    sub.subtype = textTrackTypes[trackData.kind];
+    sub.name = trackData.language;
+    sub.language = trackData.language;
+    return sub;
+  }
+
+  /**
+   * _onChangeTrack
+   * @private
+   */
+  _onChangeTrack () {
+    var castSession =
+        cast.framework.CastContext.getInstance().getCurrentSession(),
+      media = castSession.getMediaSession(),
+      noop = function () {
+        /* noop */
+     }
+      index,
+      subtitles,
+      tracksInfoRequest,
+      i;
+
+    // TODO: investigate the case when we're trying to change track while there's no `media` (yet?)
+    if (castSession && media) {
+      index = [];
+      subtitles = this.videojsPlayer.remoteTextTracks();
+      for (i = 0; i < subtitles.length; i++) {
+        if (subtitles[i].mode === "showing") {
+          index = [i];
+        }
+      }
+      tracksInfoRequest = new chrome.cast.media.EditTracksInfoRequest(index);
+
+      media.editTracksInfo(tracksInfoRequest, noop, noop);
+    }
+  }
+
+  /**
+   * Plays the given source, beginning at an optional starting time.
+   *
+   * @private
+   * @param source {object} the source to play
+   * @param [startTime] The time to start playback at, in seconds
+   * @see {@link http://docs.videojs.com/Player.html#src}
+   */
+  _playSource(source, startTime) {
+    var castSession = this._getCastSession(),
+      loadSource = this._requestLoadSource(source),
+      mediaInfo = new chrome.cast.media.MediaInfo(
+        loadSource.src,
+        loadSource.type
+      ),
+      title = this._requestTitle(source),
+      subtitle = this._requestSubtitle(source),
+      customData = this._requestCustomData(source),
+      textTrackJsonTracks = this.videojsPlayer.textTracksJson_,
+      request,
+      castSessionObj,
+      i;
+
+    this.trigger("waiting");
+    this._clearSessionTimeout();
+
+    // if more then one source was load, load queue
+    if (loadSource.sources) {
+      this._queue = loadSource.sources;
+      const queueMediaInfo = loadSource.sources.map((queueItem) => {
+        const mediaInfoItem = new chrome.cast.media.MediaInfo(
+          queueItem.src,
+          queueItem.type
+        );
+
+        mediaInfoItem.entity = queueItem.entity;
+
+        mediaInfoItem.contentUrl = queueItem.src;
+        mediaInfoItem.metadata = new chrome.cast.media.GenericMediaMetadata();
+        mediaInfoItem.metadata.title = queueItem.title;
+        mediaInfoItem.duration = queueItem.duration;
+        mediaInfoItem.metadata.subtitle = queueItem.subtitle;
+        mediaInfoItem.streamType =
+          this.videojsPlayer.liveTracker &&
+          this.videojsPlayer.liveTracker.isLive()
+            ? chrome.cast.media.StreamType.LIVE
+            : chrome.cast.media.StreamType.BUFFERED;
+        mediaInfoItem.tracks = [];
+        mediaInfoItem.activeTrackIds = [];
+        return new chrome.cast.media.QueueItem(mediaInfoItem);
+      });
+
+      request = new chrome.cast.media.LoadRequest();
+      request.startIndex = loadSource.startIndex;
+      request.queueData = new chrome.cast.media.QueueData(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        queueMediaInfo,
+        loadSource.startIndex,
+        loadSource.startTime
+      );
+    } else {
+      this._queue = null;
+      mediaInfo.entity = loadSource.entity;
+      mediaInfo.contentUrl = loadSource.src;
+      mediaInfo.contentType = loadSource.type;
+
+      mediaInfo.metadata = new chrome.cast.media.GenericMediaMetadata();
+      mediaInfo.metadata.metadataType = chrome.cast.media.MetadataType.GENERIC;
+      mediaInfo.metadata.title = title;
+      mediaInfo.metadata.subtitle = subtitle;
+      mediaInfo.streamType =
+        this.videojsPlayer.liveTracker &&
+        this.videojsPlayer.liveTracker.isLive()
+          ? chrome.cast.media.StreamType.LIVE
+          : chrome.cast.media.StreamType.BUFFERED;
+      mediaInfo.tracks = [];
+      mediaInfo.activeTrackIds = [];
+
+      for (i = 0; i < textTrackJsonTracks.length; i++) {
+        mediaInfo.tracks.push(this.generateTrack(textTrackJsonTracks[i], i));
+        if (textTrackJsonTracks[i].mode === "showing") {
+          mediaInfo.activeTrackIds.push(i);
+        }
+      }
+
+      if (customData) {
+        mediaInfo.customData = customData;
+      }
+      request = new chrome.cast.media.LoadRequest(mediaInfo);
+    }
+
+    request.autoplay = true;
+    request.currentTime =
+      startTime === undefined ? loadSource.startTime : startTime;
+    request.customData = this._requestCustomData();
+    if (loadSource.credentials) {
+      const credentialsData = new chrome.cast.CredentialsData(
+        loadSource.credentials
+      );
+
+      request = { ...request, ...credentialsData };
+    }
+    request = this._modifyLoadRequestFn(request);
+
+    this._isMediaLoading = true;
+    this._hasPlayedCurrentItem = false;
+    this._ui.updateTitle(title);
+    this._ui.updateSubtitle(subtitle);
+    castSessionObj = castSession.getSessionObj();
+    castSessionObj.loadMedia(
+      request,
+      this.onLoadSessionSuccess.bind(this),
+      this._triggerErrorEvent.bind(this)
+    );
+  }
+
+  /**
+   * onLoadSessionSuccess
+   */
+  onLoadSessionSuccess () {
+    if (!this._hasPlayedAnyItem) {
+      // `triggerReady` is required here to notify the Video.js player that the
+      // Tech has been initialized and is ready.
+      this.triggerReady();
+    }
+
+    this.trigger("loadstart");
+    this.trigger("loadeddata");
+    this.trigger("play");
+    this.trigger("playing");
+    this.videojsPlayer.hasStarted(true);
+    this._hasPlayedAnyItem = true;
+    this._isMediaLoading = false;
+    clearTimeout(this.playStateValidationTimeout);
+    this.playStateValidationTimeout = window.setTimeout(
+      this.validatePlayState.bind(this),
+      1000
+    );
+    this._getMediaSession().addUpdateListener(
+      this._onMediaSessionStatusChanged.bind(this)
+    );
+  }
+
+  /**
+   * Validate play state to make sure Chromecast and local player are in sync.
+   */
+  validatePlayState () {
+    var textTrackDisplay = this.videojsPlayer.getChild("TextTrackDisplay");
+
+    this._triggerTimeUpdateEvent();
+    this._onPlayerStateChanged();
+    this._onChangeTrack();
+
+    if (textTrackDisplay) {
+      textTrackDisplay.hide();
+    }
+  }
+
+  /**
+   * Manually updates the current time. The playback position will jump to the given time
+   * and continue playing if the item was playing when `setCurrentTime` was called, or
+   * remain paused if the item was paused.
+   *
+   * @param time {number} the playback time position to jump to
+   * @see {@link http://docs.videojs.com/Tech.html#setCurrentTime}
+   */
+  setCurrentTime (time) {
+    if (this.scrubbing()) {
+      this._scrubbingTime = time;
+      return false;
+    }
+    const duration = this.duration();
+
+    if (time > duration || !this._remotePlayer.canSeek) {
+      return;
+    }
+
+    // We need to delay the actual seeking, because when you
+    // scrub, videojs does pause() -> setCurrentTime() -> play()
+    // and that triggers a weird bug where the chromecast stops sending
+    // time_changed events.
+    this._isSeeking = true;
+    setTimeout(() => {
+      // Seeking to any place within (approximately) 1 second of the end of the item
+      // causes the Video.js player to get stuck in a BUFFERING state. To work around
+      // this, we only allow seeking to within 1 second of the end of an item.
+      this._remotePlayer.currentTime = Math.min(duration - 1, time);
+      this._remotePlayerController.seek();
+      this._isSeeking = false;
+   } 500);
+    this._triggerTimeUpdateEvent();
+  }
+
+  seeking () {
+    return this._isSeeking;
+  }
+
+  scrubbing () {
+    return this._isScrubbing;
+  }
+
+  setScrubbing (newValue) {
+    if (newValue === true) {
+      this._scrubbingTime = this.currentTime();
+      this._isScrubbing = true;
+    } else {
+      this._isScrubbing = false;
+      this.setCurrentTime(this._scrubbingTime);
+    }
+ }
+
+  /**
+   * Returns the current playback time position.
+   *
+   * @returns {number} the current playback time position
+   * @see {@link http://docs.videojs.com/Player.html#currentTime}
+   */
+  currentTime () {
+    // There is a brief period of time when Video.js has switched to the chromecast
+    // Tech, but chromecast has not yet loaded its first media item. During that time,
+    // Video.js calls this `currentTime` function to update its player UI. In that
+    // period, `this._remotePlayer.currentTime` will be 0 because the media has not
+    // loaded yet. To prevent the UI from using a 0 second currentTime, we use the
+    // currentTime passed in to the first media item that was provided to the Tech until
+    // chromecast plays its first item.
+    if (!this._hasPlayedAnyItem) {
+      return this._initialStartTime;
+    }
+    if (this.scrubbing() || this.seeking()) {
+      return this._scrubbingTime;
+    }
+    return this._remotePlayer.currentTime;
+  }
+
+  /**
+   * Returns the duration of the current media item, or `0` if the source is not set or
+   * if the duration of the item is not available from the Chromecast API yet.
+   *
+   * @returns {number} the duration of the current media item
+   * @see {@link http://docs.videojs.com/Player.html#duration}
+   */
+  duration () {
+    // There is a brief period of time when Video.js has switched to the chromecast
+    // Tech, but chromecast has not yet loaded its first media item. During that time,
+    // Video.js calls this `duration` function to update its player UI. In that period,
+    // `this._remotePlayer.duration` will be 0 because the media has not loaded yet. To
+    // prevent the UI from using a 0 second duration, we use the duration passed in to
+    // the first media item that was provided to the Tech until chromecast plays its
+    // first item.
+    if (!this._hasPlayedAnyItem) {
+      return this.videojsPlayer.duration();
+    }
+    return this._remotePlayer.duration;
+  }
+
+  /**
+   * Returns whether or not the current media item has finished playing. Returns `false`
+   * if a media item has not been loaded, has not been played, or has not yet finished
+   * playing.
+   *
+   * @returns {boolean} true if the current media item has finished playing
+   * @see {@link http://docs.videojs.com/Player.html#ended}
+   */
+  ended () {
+    var mediaSession = this._getMediaSession();
+
+    // Don't check for queues
+    // When handling a queue there are moments when mediaSession is null and current item has already finished
+    // and the new item is not started loading yet, which would end the session.
+    if (this._queue) {
+      return false;
+    }
+    if (!mediaSession && this._hasMediaSessionEnded && !this._isMediaLoading) {
+      return true;
+    }
+    return mediaSession
+      ? mediaSession.idleReason === chrome.cast.media.IdleReason.FINISHED
+      : false;
+  }
+
+  /**
+   * Returns the current volume level setting as a decimal number between `0` and `1`.
+   *
+   * @returns {number} the current volume level
+   * @see {@link http://docs.videojs.com/Player.html#volume}
+   */
+  volume () {
+    return this._remotePlayer.volumeLevel;
+  }
+
+  /**
+   * Sets the current volume level. Volume level is a decimal number between `0` and `1`,
+   * where `0` is muted and `1` is the loudest volume level.
+   *
+   * @param volumeLevel {number}
+   * @returns {number} the current volume level
+   * @see {@link http://docs.videojs.com/Player.html#volume}
+   */
+  setVolume (volumeLevel) {
+    this._remotePlayer.volumeLevel = volumeLevel;
+    this._remotePlayerController.setVolumeLevel();
+    // This event is triggered by the listener on
+    // `RemotePlayerEventType.VOLUME_LEVEL_CHANGED`, but waiting for that event to fire
+    // in response to calls to `setVolume` introduces noticeable lag in the updating of
+    // the player UI's volume slider bar, which makes user interaction with the volume
+    // slider choppy.
+    this._triggerVolumeChangeEvent();
+  }
+
+  /**
+   * Returns whether or not the player is currently muted.
+   *
+   * @returns {boolean} true if the player is currently muted
+   * @see {@link http://docs.videojs.com/Player.html#muted}
+   */
+  muted () {
+    return this._remotePlayer.isMuted;
+  }
+
+  /**
+   * Mutes or un-mutes the player. Does nothing if the player is currently muted and the
+   * `isMuted` parameter is true or if the player is not muted and `isMuted` is false.
+   *
+   * @param isMuted {boolean} whether or not the player should be muted
+   * @see {@link http://docs.videojs.com/Html5.html#setMuted} for an example
+   */
+  setMuted (isMuted) {
+    if (
+      (this._remotePlayer.isMuted && !isMuted) ||
+      (!this._remotePlayer.isMuted && isMuted)
+    ) {
+      this._remotePlayerController.muteOrUnmute();
+    }
+  }
+
+  /**
+   * Gets the URL to the current poster image.
+   *
+   * @returns {string} URL to the current poster image or `undefined` if none exists
+   * @see {@link http://docs.videojs.com/Player.html#poster}
+   */
+  poster () {
+    return this._ui.getPoster();
+  }
+
+  /**
+   * Sets the URL to the current poster image. The poster image shown in the Chromecast
+   * Tech UI view is updated with this new URL.
+   *
+   * @param poster {string} the URL to the new poster image
+   * @see {@link http://docs.videojs.com/Tech.html#setPoster}
+   */
+  setPoster (poster) {
+    this._ui.updatePoster(poster);
+  }
+
+  /**
+   * This function is "required" when implementing {@link external:Tech} and is supposed
+   * to return a mock
+   * {@link https://developer.mozilla.org/en-US/docs/Web/API/TimeRanges|TimeRanges}
+   * object that represents the portions of the current media item that have been
+   * buffered. However, the Chromecast API does not currently provide a way to determine
+   * how much the media item has buffered, so we always return `undefined`.
+   *
+   * Returning `undefined` is safe: the player will simply not display the buffer amount
+   * indicator in the scrubber UI.
+   *
+   * @returns {undefined} always returns `undefined`
+   * @see {@link http://docs.videojs.com/Player.html#buffered}
+   */
+  buffered () {
+    return undefined;
+  }
+
+  /**
+   * This function is "required" when implementing {@link external:Tech} and is supposed
+   * to return a mock
+   * {@link https://developer.mozilla.org/en-US/docs/Web/API/TimeRanges|TimeRanges}
+   * object that represents the portions of the current media item that has playable
+   * content. However, the Chromecast API does not currently provide a way to determine
+   * how much the media item has playable content, so we'll just assume the entire video
+   * is an available seek target.
+   *
+   * The risk here lies with live streaming, where there may exist a sliding window of
+   * playable content and seeking is only possible within the last X number of minutes,
+   * rather than for the entire video.
+   *
+   * Unfortunately we have no way of detecting when this is the case. Returning anything
+   * other than the full range of the video means that we lose the ability to seek during
+   * VOD.
+   *
+   * @returns {TimeRanges} always returns a `TimeRanges` object with one `TimeRange` that
+   * starts at `0` and ends at the `duration` of the current media item
+   * @see {@link http://docs.videojs.com/Player.html#seekable}
+   */
+  seekable () {
+    // TODO Investigate if there's a way to detect if the source is live, so that we can
+    // possibly adjust the seekable `TimeRanges` accordingly.
+    return this.videojs.createTimeRange(0, this.duration());
+  }
+
+  /**
+   * Returns whether the native media controls should be shown (`true`) or hidden
+   * (`false`). Not applicable to this Tech.
+   *
+   * @returns {boolean} always returns `false`
+   * @see {@link http://docs.videojs.com/Html5.html#controls} for an example
+   */
+  controls () {
+    return false;
+  }
+
+  /**
+   * Returns whether or not the browser should show the player "inline" (non-fullscreen)
+   * by default. This function always returns true to tell the browser that non-
+   * fullscreen playback is preferred.
+   *
+   * @returns {boolean} always returns `true`
+   * @see {@link http://docs.videojs.com/Html5.html#playsinline} for an example
+   */
+  playsinline () {
+    return true;
+  }
+
+  /**
+   * Returns whether or not fullscreen is supported by this Tech. Always returns `true`
+   * because fullscreen is always supported.
+   *
+   * @returns {boolean} always returns `true`
+   * @see {@link http://docs.videojs.com/Html5.html#supportsFullScreen} for an example
+   */
+  supportsFullScreen () {
+    return true;
+  }
+
+  /**
+   * Sets a flag that determines whether or not the media should automatically begin
+   * playing on page load. This is not supported because a Chromecast session must be
+   * initiated by casting via the casting menu and cannot autoplay.
+   *
+   * @see {@link http://docs.videojs.com/Html5.html#setAutoplay} for an example
+   */
+  setAutoplay () {
+    // Not supported
+  }
+
+  /**
+   * @returns {number} the chromecast player's playback rate, if available. Otherwise,
+   * the return value defaults to `1`.
+   */
+  playbackRate () {
+    var mediaSession = this._getMediaSession();
+
+    return mediaSession ? mediaSession.playbackRate : 1;
+  }
+
+  /**
+   * Does nothing. Changing the playback rate is not supported.
+   */
+  setPlaybackRate () {
+    // Not supported
+  }
+
+  /**
+   * Does nothing. Satisfies calls to the missing preload method.
+   */
+  preload () {
+    // Not supported
+  }
+
+  /**
+   * Causes the Tech to begin loading the current source. `load` is not supported in this
+   * ChromecastTech because setting the source on the `Chromecast` automatically causes
+   * it to begin loading.
+   */
+  load () {
+    // Not supported
+  }
+
+  /**
+   * Gets the Chromecast equivalent of HTML5 Media Element's `readyState`.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/readyState
+   */
+  readyState () {
+    if (
+      this._remotePlayer.playerState === "IDLE" ||
+      this._remotePlayer.playerState === "BUFFERING"
+    ) {
+      return 0; // HAVE_NOTHING
+    }
+    return 4;
+  }
+
+  /**
+   * Wires up event listeners for
+   * [RemotePlayerController](https://developers.google.com/cast/docs/reference/chrome/cast.framework.RemotePlayerController)
+   * events.
+   *
+   * @private
+   */
+  _listenToPlayerControllerEvents () {
+    var eventTypes = cast.framework.RemotePlayerEventType;
+
+    this._addEventListener(
+      this._remotePlayerController,
+      eventTypes.MEDIA_INFO_CHANGED,
+      () => {
+        if (typeof this._getMediaSession().activeTrackIds[0] === "number") {
+          const id = this._getMediaSession().activeTrackIds[0];
+
+          const tracks = this._getMediaSession().media.tracks;
+
+          const name = tracks[id].name;
+
+          this._onChangeSubtitleTrack({ name });
+        } else {
+          this._onChangeSubtitleTrack(null);
+        }
+     }
+      this
+    );
+    this._addEventListener(
+      this._remotePlayerController,
+      eventTypes.PLAYER_STATE_CHANGED,
+      this._onPlayerStateChanged,
+      this
+    );
+    this._addEventListener(
+      this._remotePlayerController,
+      eventTypes.VOLUME_LEVEL_CHANGED,
+      this._triggerVolumeChangeEvent,
+      this
+    );
+    this._addEventListener(
+      this._remotePlayerController,
+      eventTypes.IS_MUTED_CHANGED,
+      this._triggerVolumeChangeEvent,
+      this
+    );
+    this._addEventListener(
+      this._remotePlayerController,
+      eventTypes.CURRENT_TIME_CHANGED,
+      this._triggerTimeUpdateEvent,
+      this
+    );
+    this._addEventListener(
+      this._remotePlayerController,
+      eventTypes.DURATION_CHANGED,
+      this._triggerDurationChangeEvent,
+      this
+    );
+    // If any subtitles were loaded on cast receiver side,
+    // check if they exist on web player side, if not add them
+    this._addEventListener(
+      this._remotePlayerController,
+      eventTypes.MEDIA_INFO_CHANGED,
+      (event) => {
+        this.videojsPlayer.remoteTextTracks();
+        const alreadyLoadedTracks =
+          this.videojsPlayer.remoteTextTracks().tracks_;
+
+        const player = this.videojsPlayer;
+
+        if (event.value && event.value.tracks) {
+          event.value.tracks.forEach(function (track) {
+            const isAlreadyLoaded = alreadyLoadedTracks.some(function (
+              alreadyLoadedTrack
+            ) {
+              return alreadyLoadedTrack.id === track.name;
+            });
+
+            if (!isAlreadyLoaded) {
+              track.id = track.name;
+              player.addRemoteTextTrack(track);
+            }
+          });
+        }
+      }
+    );
+    this._addEventListener(
+      this._remotePlayerController,
+      eventTypes.MEDIA_INFO_CHANGED,
+      this._handleMediaInfoChangeEvent,
+      this
+    );
+  }
+
+  /**
+   * Registers an event listener on the given target object. Because many objects in the
+   * Chromecast API are either singletons or must be shared between instances of
+   * `ChromecastTech` for the lifetime of the player, we must unbind the listeners when
+   * this Tech instance is destroyed to prevent memory leaks. To do that, we need to keep
+   * a reference to listeners that are added to global objects so that we can use those
+   * references to remove the listener when this Tech is destroyed.
+   *
+   * @param target {object} the object to register the event listener on
+   * @param type {string} the name of the event
+   * @param callback {Function} the listener's callback function that executes when the
+   * event is emitted
+   * @param context {object} the `this` context to use when executing the `callback`
+   * @private
+   */
+  _addEventListener (target, type, callback, context) {
+    var listener;
+
+    listener = {
+      target: target,
+      type: type,
+      callback: callback,
+      context: context,
+      listener: callback.bind(context),
+    };
+    target.addEventListener(type, listener.listener);
+    this._eventListeners.push(listener);
+  }
+
+  /**
+   * _onDispose
+   * @private
+   */
+  _onDispose () {
+    var textTrackDisplay = this.videojsPlayer.getChild("TextTrackDisplay");
+
+    if (textTrackDisplay) {
+      textTrackDisplay.show();
+    }
+    clearTimeout(this.playStateValidationTimeout);
+    this._removeAllEventListeners();
+    // even with `stopCasting === false`, `endCurrentSession` *stops* casting
+    // this._getCastContext().endCurrentSession(/* stopCasting */ false);
+  }
+
+  /**
+   * Removes all event listeners that were registered with global objects during the
+   * lifetime of this Tech. See {@link _addEventListener} for more information about why
+   * this is necessary.
+   *
+   * @private
+   */
+  _removeAllEventListeners () {
+    while (this._eventListeners.length > 0) {
+      this._removeEventListener(this._eventListeners[0]);
+    }
+    this._eventListeners = [];
+  }
+
+  /**
+   * Removes a single event listener that was registered with global objects during the
+   * lifetime of this Tech. See {@link _addEventListener} for more information about why
+   * this is necessary.
+   *
+   * @private
+   */
+  _removeEventListener(listener) {
+    var index = -1,
+      pass = false,
+      i;
+
+    listener.target.removeEventListener(listener.type, listener.listener);
+
+    for (i = 0; i < this._eventListeners.length; i++) {
+      pass =
+        this._eventListeners[i].target === listener.target &&
+        this._eventListeners[i].type === listener.type &&
+        this._eventListeners[i].callback === listener.callback &&
+        this._eventListeners[i].context === listener.context;
+
+      if (pass) {
+        index = i;
+        break;
+      }
+    }
+
+    if (index !== -1) {
+      this._eventListeners.splice(index, 1);
+    }
+  }
+
+  /**
+   * Handles Chromecast player state change events. The player may "change state" when
+   * paused, played, buffering, etc.
+   *
+   * @private
+   */
+  _onPlayerStateChanged () {
+    var states = chrome.cast.media.PlayerState,
+      playerState = this._remotePlayer.playerState;
+
+    if (playerState === states.PLAYING) {
+      this._hasPlayedCurrentItem = true;
+      this.trigger("play");
+      this.trigger("playing");
+    } else if (playerState === states.PAUSED) {
+      this.trigger("pause");
+    } else if (
+      (playerState === states.IDLE && this.ended()) ||
+      (playerState === null && this._hasPlayedCurrentItem)
+    ) {
+      this._hasPlayedCurrentItem = false;
+      this._closeSessionOnTimeout();
+      this.trigger("ended");
+      this._triggerTimeUpdateEvent();
+    } else if (playerState === states.BUFFERING) {
+      this.trigger("waiting");
+    }
+  }
+
+  /**
+   * Handles Chromecast MediaSession state change events. The only property sent to this
+   * event is whether the session is alive. This is useful for determining if an item has
+   * ended as the MediaSession will fire this event with `false` then be immediately
+   * destroyed. This means that we cannot trust `idleReason` to show whether an item has
+   * ended since we may no longer have access to the MediaSession.
+   *
+   * @private
+   */
+  _onMediaSessionStatusChanged (isAlive) {
+    this._hasMediaSessionEnded = !!isAlive;
+  }
+
+  /**
+   * Ends the session after a certain number of seconds of inactivity.
+   *
+   * If the Chromecast player is in the "IDLE" state after an item has ended, and no
+   * further items are queued up to play, the session is considered inactive. Once a
+   * period of time (currently 10 seconds) has elapsed with no activity, we manually end
+   * the session to prevent long periods of a blank Chromecast screen that is shown at
+   * the end of item playback.
+   *
+   * @private
+   */
+  _closeSessionOnTimeout () {
+    // Ensure that there's never more than one session timeout active
+    this._clearSessionTimeout();
+    this._sessionTimeoutID = setTimeout(
+      function () {
+        var castSession = this._getCastSession();
+
+        if (castSession) {
+          castSession.endSession(true);
+        }
+        this._clearSessionTimeout();
+      }.bind(this),
+      SESSION_TIMEOUT
+    );
+  }
+
+  /**
+   * Stops the timeout that is waiting during a period of inactivity in order to close
+   * the session.
+   *
+   * @private
+   * @see _closeSessionOnTimeout
+   */
+  _clearSessionTimeout () {
+    if (this._sessionTimeoutID) {
+      clearTimeout(this._sessionTimeoutID);
+      this._sessionTimeoutID = false;
+    }
+  }
+
+  /**
+   * @private
+   * @return {object} the current CastContext, if one exists
+   */
+  _getCastContext() {
+    return this._chromecastSessionManager.getCastContext();
+ }
+
+  /**
+   * @private
+   * @return {object} the current CastSession, if one exists
+   */
+  _getCastSession() {
+    return this._getCastContext().getCurrentSession();
+ }
+
+  /**
+   * @private
+   * @return {object} the current MediaSession, if one exists
+   * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.Media
+   */
+  _getMediaSession() {
+    var castSession = this._getCastSession();
+
+    return castSession ? castSession.getMediaSession() : null;
+ }
+
+  /**
+   * Triggers a 'volumechange' event
+   * @private
+   * @see http://docs.videojs.com/Player.html#event:volumechange
+   */
+  _triggerVolumeChangeEvent() {
+    this.trigger("volumechange");
+ }
+
+  /**
+   * Triggers a 'timeupdate' event
+   * @private
+   * @see http://docs.videojs.com/Player.html#event:timeupdate
+   */
+  _triggerTimeUpdateEvent() {
+    this.trigger("timeupdate");
+ }
+
+  /**
+   * Triggers a 'durationchange' event
+   * @private
+   * @see http://docs.videojs.com/Player.html#event:durationchange
+   */
+  _triggerDurationChangeEvent() {
+    this.trigger("durationchange");
+ }
+
+  /**
+   * @private
+   */
+  _handleMediaInfoChangeEvent: function (event) {
+    this._requestQueueItemChange(event);
+ }
+
+  /**
+   * Triggers an 'error' event
+   * @private
+   * @see http://docs.videojs.com/Player.html#event:error
+   */
+  _triggerErrorEvent() {
+    this.trigger("error");
+ }
+};
+
+/**
+ * Registers the ChromecastTech Tech with Video.js. Calls {@link
+ * http://docs.videojs.com/Tech.html#.registerTech}, which will add a Tech called
+ * `chromecast` to the list of globally registered Video.js Tech implementations.
+ *
+ * [Video.js Tech](http://docs.videojs.com/Tech.html) are initialized and used
+ * automatically by Video.js Player instances. Whenever a new source is set on the player,
+ * the player iterates through the list of available Tech to determine which to use to
+ * play the source.
+ *
+ * @param videojs {object} A reference to
+ * {@link http://docs.videojs.com/module-videojs.html|Video.js}
+ * @see http://docs.videojs.com/Tech.html#.registerTech
+ */
+module.exports = function (videojs) {
+  var Tech = videojs.getComponent("Tech"),
+    SESSION_TIMEOUT = 10 * 1000; // milliseconds
+
+  /**
+   * @module ChomecastTech
+   */
+
+  /**
+   * The Video.js Tech class is the base class for classes that provide media playback
+   * technology implementations to Video.js such as HTML5, Flash and HLS.
+   *
+   * @external Tech
+   * @see {@link http://docs.videojs.com/Tech.html|Tech}
+   */
+
+  /** @lends ChromecastTech.prototype */
+  class ChromecastTech extends Tech {
+    /**
+     * Implements Video.js playback {@link http://docs.videojs.com/tutorial-tech_.html|Tech}
+     * for {@link https://developers.google.com/cast/|Google's Chromecast}.
+     *
+     * @constructs ChromecastTech
+     * @extends external:Tech
+     * @param options {object} The options to use for configuration
+     * @see {@link https://developers.google.com/cast/|Google Cast}
+     */
+    constructor(options) {
+      super(options);
+
+      this.featuresVolumeControl = true;
+      this.featuresPlaybackRate = false;
+      this.movingMediaElementInDOM = false;
+      this.featuresFullscreenResize = true;
+      this.featuresTimeupdateEvents = true;
+      this.featuresProgressEvents = false;
+      // Text tracks are not supported in this version
+      this.featuresNativeTextTracks = false;
+      this.featuresNativeAudioTracks = false;
+      this.featuresNativeVideoTracks = false;
+
+      // Give ChromecastTech class instances a reference to videojs
+      this.videojs = videojs;
+      this._eventListeners = [];
+
+      this.videojsPlayer = this.videojs(options.playerId);
+      this._chromecastSessionManager =
+        this.videojsPlayer.chromecastSessionManager;
+
+      this._ui.updatePoster(this.videojsPlayer.poster());
+
+      this._remotePlayer = this._chromecastSessionManager.getRemotePlayer();
+      this._remotePlayerController =
+        this._chromecastSessionManager.getRemotePlayerController();
+      this._listenToPlayerControllerEvents();
+      this.on("dispose", this._removeAllEventListeners.bind(this));
+
+      this._hasPlayedAnyItem = false;
+      this._requestTitle =
+        options.requestTitleFn ||
+        function () {
+          /* noop */
+        };
+      this._requestSubtitle =
+        options.requestSubtitleFn ||
+        function () {
+          /* noop */
+        };
+      this._requestCustomData =
+        options.requestCustomDataFn ||
+        function () {
+          /* noop */
+        };
+      // See `currentTime` function
+      this._initialStartTime = options.startTime || 0;
+
+      this._playSource(options.source, this._initialStartTime);
+      this.ready(
+        function () {
+          this.setMuted(options.muted);
+        }.bind(this)
+      );
+    }
+
+    /**
+     * Creates a DOMElement that Video.js displays in its player UI while this Tech is
+     * active.
+     *
+     * @returns {DOMElement}
+     * @see {@link http://docs.videojs.com/Tech.html#createEl}
+     */
+    createEl() {
+      // We have to initialize the UI here, because the super.constructor
+      // calls `createEl`, which references `this._ui`.
+      this._ui = this._ui || new ChromecastTechUI();
+
+      return this._ui.getDOMElement();
+    }
+
+    /**
+     * Resumes playback if a media item is paused or restarts an item from
+     * its beginning if the item has played and ended.
+     *
+     * @see {@link http://docs.videojs.com/Player.html#play}
+     */
+    play() {
+      if (!this.paused()) {
+        return;
+      }
+      if (this.ended() && !this._isMediaLoading) {
+        // Restart the current item from the beginning
+        this._playSource({ src: this.videojsPlayer.src() }, 0);
+      } else {
+        this._remotePlayerController.playOrPause();
+      }
+    }
+
+    /**
+     * Pauses playback if the player is not already paused and if the current media item
+     * has not ended yet.
+     *
+     * @see {@link http://docs.videojs.com/Player.html#pause}
+     */
+    pause() {
+      if (!this.paused() && this._remotePlayer.canPause) {
+        this._remotePlayerController.playOrPause();
+      }
+    }
+
+    /**
+     * Returns whether or not the player is "paused". Video.js'
+     * definition of "paused" is "playback paused" OR "not playing".
+     *
+     * @returns {boolean} true if playback is paused
+     * @see {@link http://docs.videojs.com/Player.html#paused}
+     */
+    paused() {
+      return (
+        this._remotePlayer.isPaused ||
+        this.ended() ||
+        this._remotePlayer.playerState === null
+      );
+    }
+
+    /**
+     * Stores the given source and begins playback, starting at the beginning
+     * of the media item.
+     *
+     * @param source {object} the source to store and play
+     * @see {@link http://docs.videojs.com/Player.html#src}
+     */
+    setSource(source) {
+      if (
+        this._currentSource &&
+        this._currentSource.src === source.src &&
+        this._currentSource.type === source.type
+      ) {
+        // Skip setting the source if the `source` argument is the
+        // same as what's already been set. This `setSource` function
+        // calls `this._playSource` which sends a "load media" request
+        // to the Chromecast PlayerController. Because this function
+        // may be called multiple times in rapid succession with the same `source`
+        // argument, we need to de-duplicate calls with the same `source` argument to
+        // prevent overwhelming the Chromecast PlayerController with expensive "load
+        // media" requests, which it itself does not de-duplicate.
+        return;
+      }
+      // We cannot use `this.videojsPlayer.currentSource()` because the
+      // value returned by that function is not the same as what's returned
+      // by the Video.js Player's middleware after they are run. Also, simply
+      // using `this.videojsPlayer.src()` does not include mimetype information
+      // which we pass to the Chromecast player.
+      this._currentSource = source;
+      this._playSource(source, 0);
+    }
+
+    /**
+     * Plays the given source, beginning at an optional starting time.
+     *
+     * @private
+     * @param source {object} the source to play
+     * @param [startTime] The time to start playback at, in seconds
+     * @see {@link http://docs.videojs.com/Player.html#src}
+     */
+    _playSource(source, startTime) {
+      var castSession = this._getCastSession(),
+        mediaInfo = new chrome.cast.media.MediaInfo(source.src, source.type),
+        title = this._requestTitle(source),
+        subtitle = this._requestSubtitle(source),
+        poster = this.poster(),
+        customData = this._requestCustomData(source),
+        request;
+
+      this.trigger("waiting");
+      this._clearSessionTimeout();
+
+      mediaInfo.metadata = new chrome.cast.media.GenericMediaMetadata();
+      mediaInfo.metadata.metadataType = chrome.cast.media.MetadataType.GENERIC;
+      mediaInfo.metadata.title = title;
+      mediaInfo.metadata.subtitle = subtitle;
+      mediaInfo.streamType =
+        this.videojsPlayer.liveTracker &&
+        this.videojsPlayer.liveTracker.isLive()
+          ? chrome.cast.media.StreamType.LIVE
+          : chrome.cast.media.StreamType.BUFFERED;
+
+      if (poster) {
+        mediaInfo.metadata.images = [{ url: poster }];
+      }
+      if (customData) {
+        mediaInfo.customData = customData;
+      }
+
+      this._ui.updateTitle(title);
+      this._ui.updateSubtitle(subtitle);
+
+      request = new chrome.cast.media.LoadRequest(mediaInfo);
+      request.autoplay = true;
+      request.currentTime = startTime;
+
+      this._isMediaLoading = true;
+      this._hasPlayedCurrentItem = false;
+      castSession.loadMedia(request).then(
+        function () {
+          if (!this._hasPlayedAnyItem) {
+            // `triggerReady` is required here to notify the Video.js
+            // player that the Tech has been initialized and is ready.
+            this.triggerReady();
+          }
+          this.trigger("loadstart");
+          this.trigger("loadeddata");
+          this.trigger("play");
+          this.trigger("playing");
+          this._hasPlayedAnyItem = true;
+          this._isMediaLoading = false;
+          this._getMediaSession().addUpdateListener(
+            this._onMediaSessionStatusChanged.bind(this)
+          );
+        }.bind(this),
+        this._triggerErrorEvent.bind(this)
+      );
+    }
+
+    /**
+     * Manually updates the current time. The playback position will jump to
+     * the given time and continue playing if the item was playing when `setCurrentTime`
+     * was called, or remain paused if the item was paused.
+     *
+     * @param time {number} the playback time position to jump to
+     * @see {@link http://docs.videojs.com/Tech.html#setCurrentTime}
+     */
+    setCurrentTime(time) {
+      var duration = this.duration();
+
+      if (time > duration || !this._remotePlayer.canSeek) {
+        return;
+      }
+      // Seeking to any place within (approximately) 1 second of the end of the item
+      // causes the Video.js player to get stuck in a BUFFERING state. To work around
+      // this, we only allow seeking to within 1 second of the end of an item.
+      this._remotePlayer.currentTime = Math.min(duration - 1, time);
+      this._remotePlayerController.seek();
+      this._triggerTimeUpdateEvent();
+    }
+
+    /**
+     * Returns the current playback time position.
+     *
+     * @returns {number} the current playback time position
+     * @see {@link http://docs.videojs.com/Player.html#currentTime}
+     */
+    currentTime() {
+      // There is a brief period of time when Video.js has switched to the chromecast
+      // Tech, but chromecast has not yet loaded its first media item. During
+      // that time, Video.js calls this `currentTime` function to update
+      // its player UI. In that period, `this._remotePlayer.currentTime`
+      // will be 0 because the media has not loaded yet. To prevent the
+      // UI from using a 0 second currentTime, we use the currentTime passed
+      // in to the first media item that was provided to the Tech until
+      // chromecast plays its first item.
+      if (!this._hasPlayedAnyItem) {
+        return this._initialStartTime;
+      }
+      return this._remotePlayer.currentTime;
+    }
+
+    /**
+     * Returns the duration of the current media item, or `0` if the source
+     * is not set or if the duration of the item is not available from the
+     * Chromecast API yet.
+     *
+     * @returns {number} the duration of the current media item
+     * @see {@link http://docs.videojs.com/Player.html#duration}
+     */
+    duration() {
+      // There is a brief period of time when Video.js has switched to the chromecast
+      // Tech, but chromecast has not yet loaded its first media item.
+      // During that time, Video.js calls this `duration` function to update its player
+      // UI. In that period, `this._remotePlayer.duration` will be 0 because the media
+      // has not loaded yet. To prevent the UI from using a 0 second duration, we
+      // use the duration passed in to the first media item that was provided to
+      // the Tech until chromecast plays its first item.
+      if (!this._hasPlayedAnyItem) {
+        return this.videojsPlayer.duration();
+      }
+      return this._remotePlayer.duration;
+    }
+
+    /**
+     * Returns whether or not the current media item has finished playing.
+     * Returns `false` if a media item has not been loaded, has not been played,
+     * or has not yet finished playing.
+     *
+     * @returns {boolean} true if the current media item has finished playing
+     * @see {@link http://docs.videojs.com/Player.html#ended}
+     */
+    ended() {
+      var mediaSession = this._getMediaSession();
+
+      if (!mediaSession && this._hasMediaSessionEnded) {
+        return true;
+      }
+
+      return mediaSession
+        ? mediaSession.idleReason === chrome.cast.media.IdleReason.FINISHED
+        : false;
+    }
+
+    /**
+     * Returns the current volume level setting as a decimal number between `0` and `1`.
+     *
+     * @returns {number} the current volume level
+     * @see {@link http://docs.videojs.com/Player.html#volume}
+     */
+    volume() {
+      return this._remotePlayer.volumeLevel;
+    }
+
+    /**
+     * Sets the current volume level. Volume level is a decimal number
+     * between `0` and `1`, where `0` is muted and `1` is the loudest volume level.
+     *
+     * @param volumeLevel {number}
+     * @returns {number} the current volume level
+     * @see {@link http://docs.videojs.com/Player.html#volume}
+     */
+    setVolume(volumeLevel) {
+      this._remotePlayer.volumeLevel = volumeLevel;
+      this._remotePlayerController.setVolumeLevel();
+      // This event is triggered by the listener on
+      // `RemotePlayerEventType.VOLUME_LEVEL_CHANGED`, but waiting for
+      // that event to fire in response to calls to `setVolume` introduces
+      // noticeable lag in the updating of the player UI's volume slider bar,
+      // which makes user interaction with the volume slider choppy.
+      this._triggerVolumeChangeEvent();
+    }
+
+    /**
+     * Returns whether or not the player is currently muted.
+     *
+     * @returns {boolean} true if the player is currently muted
+     * @see {@link http://docs.videojs.com/Player.html#muted}
+     */
+    muted() {
+      return this._remotePlayer.isMuted;
+    }
+
+    /**
+     * Mutes or un-mutes the player. Does nothing if the player is currently
+     * muted and the `isMuted` parameter is true or if the player is not muted and
+     * `isMuted` is false.
+     *
+     * @param isMuted {boolean} whether or not the player should be muted
+     * @see {@link http://docs.videojs.com/Html5.html#setMuted} for an example
+     */
+    setMuted(isMuted) {
+      if (
+        (this._remotePlayer.isMuted && !isMuted) ||
+        (!this._remotePlayer.isMuted && isMuted)
+      ) {
+        this._remotePlayerController.muteOrUnmute();
+      }
+    }
+
+    /**
+     * Gets the URL to the current poster image.
+     *
+     * @returns {string} URL to the current poster image or `undefined` if none exists
+     * @see {@link http://docs.videojs.com/Player.html#poster}
+     */
+    poster() {
+      return this._ui.getPoster();
+    }
+
+    /**
+     * Sets the URL to the current poster image. The poster image shown
+     * in the Chromecast Tech UI view is updated with this new URL.
+     *
+     * @param poster {string} the URL to the new poster image
+     * @see {@link http://docs.videojs.com/Tech.html#setPoster}
+     */
+    setPoster(poster) {
+      this._ui.updatePoster(poster);
+    }
+
+    /**
+     * This function is "required" when implementing {@link external:Tech}
+     * and is supposed to return a mock
+     * {@link https://developer.mozilla.org/en-US/docs/Web/API/TimeRanges|TimeRanges}
+     * object that represents the portions of the current media item that have been
+     * buffered. However, the Chromecast API does not currently provide a way
+     * to determine how much the media item has buffered, so we always
+     * return `undefined`.
+     *
+     * Returning `undefined` is safe: the player will simply not display
+     * the buffer amount indicator in the scrubber UI.
+     *
+     * @returns {undefined} always returns `undefined`
+     * @see {@link http://docs.videojs.com/Player.html#buffered}
+     */
+    buffered() {
+      return undefined;
+    }
+
+    /**
+     * This function is "required" when implementing {@link external:Tech}
+     * and is supposed to return a mock
+     * {@link https://developer.mozilla.org/en-US/docs/Web/API/TimeRanges|TimeRanges}
+     * object that represents the portions of the current media item that has playable
+     * content. However, the Chromecast API does not currently provide a
+     * way to determine how much the media item has playable content, so
+     * we'll just assume the entire video is an available seek target.
+     *
+     * The risk here lies with live streaming, where there may exist a sliding window of
+     * playable content and seeking is only possible within the last X number of
+     * minutes, rather than for the entire video.
+     *
+     * Unfortunately we have no way of detecting when this is the case. Returning
+     * anything other than the full range of the video means that we lose the ability
+     * to seek during VOD.
+     *
+     * @returns {TimeRanges} always returns a `TimeRanges` object with one
+     * `TimeRange` that starts at `0` and ends at the `duration` of the
+     * current media item
+     * @see {@link http://docs.videojs.com/Player.html#seekable}
+     */
+    seekable() {
+      // TODO Investigate if there's a way to detect
+      // if the source is live, so that we can
+      // possibly adjust the seekable `TimeRanges` accordingly.
+      return this.videojs.createTimeRange(0, this.duration());
+    }
+
+    /**
+     * Returns whether the native media controls should be shown (`true`) or hidden
+     * (`false`). Not applicable to this Tech.
+     *
+     * @returns {boolean} always returns `false`
+     * @see {@link http://docs.videojs.com/Html5.html#controls} for an example
+     */
+    controls() {
+      return false;
+    }
+
+    /**
+     * Returns whether or not the browser should show the player
+     * "inline" (non-fullscreen) by default. This function always
+     * returns true to tell the browser that non-fullscreen playback is preferred.
+     *
+     * @returns {boolean} always returns `true`
+     * @see {@link http://docs.videojs.com/Html5.html#playsinline} for an example
+     */
+    playsinline() {
+      return true;
+    }
+
+    /**
+     * Returns whether or not fullscreen is supported by this Tech.
+     * Always returns `true` because fullscreen is always supported.
+     *
+     * @returns {boolean} always returns `true`
+     * @see {@link http://docs.videojs.com/Html5.html#supportsFullScreen} for an example
+     */
+    supportsFullScreen() {
+      return true;
+    }
+
+    /**
+     * Sets a flag that determines whether or not the media should automatically begin
+     * playing on page load. This is not supported because a Chromecast session must be
+     * initiated by casting via the casting menu and cannot autoplay.
+     *
+     * @see {@link http://docs.videojs.com/Html5.html#setAutoplay} for an example
+     */
+    setAutoplay() {
+      // Not supported
+    }
+
+    /**
+     * @returns {number} the chromecast player's playback rate, if available. Otherwise,
+     * the return value defaults to `1`.
+     */
+    playbackRate() {
+      var mediaSession = this._getMediaSession();
+
+      return mediaSession ? mediaSession.playbackRate : 1;
+    }
+
+    /**
+     * Does nothing. Changing the playback rate is not supported.
+     */
+    setPlaybackRate() {
+      // Not supported
+    }
+
+    /**
+     * Does nothing. Satisfies calls to the missing preload method.
+     */
+    preload() {
+      // Not supported
+    }
+
+    /**
+     * Causes the Tech to begin loading the current source. `load`
+     * is not supported in this ChromecastTech because setting the
+     * source on the `Chromecast` automatically causes it to begin loading.
+     */
+    load() {
+      // Not supported
+    }
+
+    /**
+     * Gets the Chromecast equivalent of HTML5 Media Element's `readyState`.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/readyState
+     */
+    readyState() {
+      if (
+        this._remotePlayer.playerState === "IDLE" ||
+        this._remotePlayer.playerState === "BUFFERING"
+      ) {
+        return 0; // HAVE_NOTHING
+      }
+      return 4;
+    }
+
+    /**
+     * Wires up event listeners for
+     * [RemotePlayerController](https://developers.google.com/cast/docs/reference/chrome/cast.framework.RemotePlayerController)
+     * events.
+     *
+     * @private
+     */
+    _listenToPlayerControllerEvents() {
+      var eventTypes = cast.framework.RemotePlayerEventType;
+
+      this._addEventListener(
+        this._remotePlayerController,
+        eventTypes.PLAYER_STATE_CHANGED,
+        this._onPlayerStateChanged,
+        this
+      );
+      this._addEventListener(
+        this._remotePlayerController,
+        eventTypes.VOLUME_LEVEL_CHANGED,
+        this._triggerVolumeChangeEvent,
+        this
+      );
+      this._addEventListener(
+        this._remotePlayerController,
+        eventTypes.IS_MUTED_CHANGED,
+        this._triggerVolumeChangeEvent,
+        this
+      );
+      this._addEventListener(
+        this._remotePlayerController,
+        eventTypes.CURRENT_TIME_CHANGED,
+        this._triggerTimeUpdateEvent,
+        this
+      );
+      this._addEventListener(
+        this._remotePlayerController,
+        eventTypes.DURATION_CHANGED,
+        this._triggerDurationChangeEvent,
+        this
+      );
+    }
+
+    /**
+     * Registers an event listener on the given target object.
+     * Because many objects in the Chromecast API are either singletons
+     * or must be shared between instances of `ChromecastTech` for the
+     * lifetime of the player, we must unbind the listeners when this Tech
+     * instance is destroyed to prevent memory leaks. To do that, we need to keep
+     * a reference to listeners that are added to global objects so that we can
+     * use those references to remove the listener when this Tech is destroyed.
+     *
+     * @param target {object} the object to register the event listener on
+     * @param type {string} the name of the event
+     * @param callback {Function} the listener's callback function that
+     * executes when the event is emitted
+     * @param context {object} the `this` context to use when executing the `callback`
+     * @private
+     */
+    _addEventListener(target, type, callback, context) {
+      var listener;
+
+      listener = {
+        target: target,
+        type: type,
+        callback: callback,
+        context: context,
+        listener: callback.bind(context),
+      };
+      target.addEventListener(type, listener.listener);
+      this._eventListeners.push(listener);
+    }
+
+    /**
+     * Removes all event listeners that were registered with global objects during the
+     * lifetime of this Tech. See {@link _addEventListener} for more information
+     * about why this is necessary.
+     *
+     * @private
+     */
+    _removeAllEventListeners() {
+      while (this._eventListeners.length > 0) {
+        this._removeEventListener(this._eventListeners[0]);
+      }
+      this._eventListeners = [];
+    }
+
+    /**
+     * Removes a single event listener that was registered with global objects
+     * during the lifetime of this Tech. See {@link _addEventListener} for
+     * more information about why this is necessary.
+     *
+     * @private
+     */
+    _removeEventListener(listener) {
+      var index = -1,
+        pass = false,
+        i;
+
+      listener.target.removeEventListener(listener.type, listener.listener);
+
+      for (i = 0; i < this._eventListeners.length; i++) {
+        pass =
+          this._eventListeners[i].target === listener.target &&
+          this._eventListeners[i].type === listener.type &&
+          this._eventListeners[i].callback === listener.callback &&
+          this._eventListeners[i].context === listener.context;
+
+        if (pass) {
+          index = i;
+          break;
+        }
+      }
+
+      if (index !== -1) {
+        this._eventListeners.splice(index, 1);
+      }
+    }
+
+    /**
+     * Handles Chromecast player state change events. The player may "change state" when
+     * paused, played, buffering, etc.
+     *
+     * @private
+     */
+    _onPlayerStateChanged() {
+      var states = chrome.cast.media.PlayerState,
+        playerState = this._remotePlayer.playerState;
+
+      if (playerState === states.PLAYING) {
+        this._hasPlayedCurrentItem = true;
+        this.trigger("play");
+        this.trigger("playing");
+      } else if (playerState === states.PAUSED) {
+        this.trigger("pause");
+      } else if (
+        (playerState === states.IDLE && this.ended()) ||
+        (playerState === null && this._hasPlayedCurrentItem)
+      ) {
+        this._hasPlayedCurrentItem = false;
+        this._closeSessionOnTimeout();
+        this.trigger("ended");
+        this._triggerTimeUpdateEvent();
+      } else if (playerState === states.BUFFERING) {
+        this.trigger("waiting");
+      }
+    }
+
+    /**
+     * Handles Chromecast MediaSession state change events. The only property sent
+     * to this event is whether the session is alive. This is useful for determining
+     * if an item has ended as the MediaSession will fire this event with `false` then
+     * be immediately destroyed. This means that we cannot trust `idleReason` to show
+     * whether an item has ended since we may no longer have access to the MediaSession.
+     *
+     * @private
+     */
+    _onMediaSessionStatusChanged(isAlive) {
+      this._hasMediaSessionEnded = !!isAlive;
+    }
+
+    /**
+     * Ends the session after a certain number of seconds of inactivity.
+     *
+     * If the Chromecast player is in the "IDLE" state after an item has ended, and no
+     * further items are queued up to play, the session is considered inactive. Once a
+     * period of time (currently 10 seconds) has elapsed with no activity, we manually
+     * end the session to prevent long periods of a blank Chromecast screen that is
+     * shown at the end of item playback.
+     *
+     * @private
+     */
+    _closeSessionOnTimeout() {
+      // Ensure that there's never more than one session timeout active
+      this._clearSessionTimeout();
+      this._sessionTimeoutID = setTimeout(
+        function () {
+          var castSession = this._getCastSession();
+
+          if (castSession) {
+            castSession.endSession(true);
+          }
+          this._clearSessionTimeout();
+        }.bind(this),
+        SESSION_TIMEOUT
+      );
+    }
+
+    /**
+     * Stops the timeout that is waiting during a period of inactivity in order to close
+     * the session.
+     *
+     * @private
+     * @see _closeSessionOnTimeout
+     */
+    _clearSessionTimeout() {
+      if (this._sessionTimeoutID) {
+        clearTimeout(this._sessionTimeoutID);
+        this._sessionTimeoutID = false;
+      }
+    }
+
+    /**
+     * @private
+     * @return {object} the current CastContext, if one exists
+     */
+    _getCastContext() {
+      return this._chromecastSessionManager.getCastContext();
+    }
+
+    /**
+     * @private
+     * @return {object} the current CastSession, if one exists
+     */
+    _getCastSession() {
+      return this._getCastContext().getCurrentSession();
+    }
+
+    /**
+     * @private
+     * @return {object} the current MediaSession, if one exists
+     * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.Media
+     */
+    _getMediaSession() {
+      var castSession = this._getCastSession();
+
+      return castSession ? castSession.getMediaSession() : null;
+    }
+
+    /**
+     * Triggers a 'volumechange' event
+     * @private
+     * @see http://docs.videojs.com/Player.html#event:volumechange
+     */
+    _triggerVolumeChangeEvent() {
+      this.trigger("volumechange");
+    }
+
+    /**
+     * Triggers a 'timeupdate' event
+     * @private
+     * @see http://docs.videojs.com/Player.html#event:timeupdate
+     */
+    _triggerTimeUpdateEvent() {
+      this.trigger("timeupdate");
+    }
+
+    /**
+     * Triggers a 'durationchange' event
+     * @private
+     * @see http://docs.videojs.com/Player.html#event:durationchange
+     */
+    _triggerDurationChangeEvent() {
+      this.trigger("durationchange");
+    }
+
+    /**
+     * Triggers an 'error' event
+     * @private
+     * @see http://docs.videojs.com/Player.html#event:error
+     */
+    _triggerErrorEvent() {
+      this.trigger("error");
+    }
+  }
+
+  // Required for Video.js Tech implementations.
+  // TODO Consider a more comprehensive check based on mimetype.
+  ChromecastTech.canPlaySource = () => {
+    return ChromecastSessionManager.isChromecastConnected();
+  };
+
+
+  videojs.registerTech("chromecast", ChromecastTech);
 };

--- a/src/js/tech/ChromecastTech.js
+++ b/src/js/tech/ChromecastTech.js
@@ -15,1144 +15,6 @@ var ChromecastSessionManager = require("../chromecast/ChromecastSessionManager")
  * {@link http://docs.videojs.com/module-videojs.html|Video.js}
  * @see http://docs.videojs.com/Tech.html#.registerTech
  */
-module.exports = function(videojs) {
-   var Tech = videojs.getComponent('Tech'),
-       SESSION_TIMEOUT = 10 * 1000; // milliseconds
-
-   /**
-    * @module ChomecastTech
-    */
-
-   /**
-    * The Video.js Tech class is the base class for classes that provide media playback
-    * technology implementations to Video.js such as HTML5, Flash and HLS.
-    *
-    * @external Tech
-    * @see {@link http://docs.videojs.com/Tech.html|Tech}
-    */
-
-   /** @lends ChromecastTech.prototype */
-   class ChromecastTech extends Tech {
-
-      /**
-       * Implements Video.js playback {@link http://docs.videojs.com/tutorial-tech_.html|Tech}
-       * for {@link https://developers.google.com/cast/|Google's Chromecast}.
-       *
-       * @constructs ChromecastTech
-       * @extends external:Tech
-       * @param options {object} The options to use for configuration
-       * @see {@link https://developers.google.com/cast/|Google Cast}
-       */
-      constructor(options) {
-         super(options);
-
-         this.featuresVolumeControl = true;
-         this.featuresPlaybackRate = false;
-         this.movingMediaElementInDOM = false;
-         this.featuresFullscreenResize = true;
-         this.featuresTimeupdateEvents = true;
-         this.featuresProgressEvents = false;
-         // Text tracks are not supported in this version
-         this.featuresNativeTextTracks = false;
-         this.featuresNativeAudioTracks = false;
-         this.featuresNativeVideoTracks = false;
-    var mediaSession, textTrackDisplay, subclass;
-
-
-         // Give ChromecastTech class instances a reference to videojs
-         this.videojs = videojs;
-         this._eventListeners = [];
-    this.options = options;
-    this.videojsPlayer = this.videojs(options.playerId);
-    this._chromecastSessionManager =
-      this.videojsPlayer.chromecastSessionManager;
-
-    // We have to initialize the UI here, before calling super.constructor
-    // because the constructor calls `createEl`, which references `this._ui`.
-    this._ui = new ChromecastTechUI();
-    this._ui.updatePoster(this.videojsPlayer.poster());
-
-    // Call the super class' constructor function
-    subclass = this.constructor.super_.apply(this, arguments);
-
-    this._remotePlayer = this._chromecastSessionManager.getRemotePlayer();
-    this._remotePlayerController =
-      this._chromecastSessionManager.getRemotePlayerController();
-    this._listenToPlayerControllerEvents();
-    this.on("dispose", this._onDispose.bind(this));
-
-    this._hasPlayedAnyItem = false;
-    this._onChangeSubtitleTrack =
-      options.onChangeSubtitleTrackFn ||
-      function () {
-        /* noop */
-      };
-    this._requestTitle =
-      options.requestTitleFn ||
-      function () {
-        /* noop */
-      };
-    this._requestSubtitle =
-      options.requestSubtitleFn ||
-      function () {
-        /* noop */
-      };
-    this._requestQueueItemChange =
-      options.requestQueueItemChangeFn ||
-      function () {
-        /* noop */
-      };
-    this._requestCustomData =
-      options.requestCustomDataFn ||
-      function () {
-        /* noop */
-      };
-    this._modifyLoadRequestFn =
-      options.modifyLoadRequestFn ||
-      function () {
-        /* noop */
-      };
-    this._requestLoadSource =
-      options.requestLoadSourceFn ||
-      function (source) {
-        return source;
-      };
-    const loadSource = this._requestLoadSource(options.source);
-
-    // See `currentTime` function
-    this._initialStartTime =
-      options.startTime === undefined
-        ? loadSource.startTime || 0
-        : options.startTime;
-    this._isScrubbing = false;
-    this._isSeeking = false;
-    this._scrubbingTime = this._initialStartTime;
-
-    mediaSession = this._getMediaSession();
-    if (
-      mediaSession &&
-      mediaSession.media &&
-      mediaSession.media.entity === loadSource.entity
-    ) {
-      this.onLoadSessionSuccess();
-    } else {
-      this._playSource(options.source);
-    }
-
-    this.ready(
-      function () {
-        this.setMuted(options.muted);
-      }.bind(this)
-    );
-    this.videojsPlayer
-      .remoteTextTracks()
-      .on("change", this._onChangeTrack.bind(this));
-    textTrackDisplay = this.videojsPlayer.getChild("TextTrackDisplay");
-
-    if (textTrackDisplay) {
-      textTrackDisplay.hide();
-    }
-
-   }
-  /**
-       * Creates a DOMElement that Video.js displays in its player UI while this Tech is
-       * active.
-       *
-       * @returns {DOMElement}
-       * @see {@link http://docs.videojs.com/Tech.html#createEl}
-       */
-  createEl() {
-   // We have to initialize the UI here, because the super.constructor
-   // calls `createEl`, which references `this._ui`.
-   this._ui = this._ui || new ChromecastTechUI();
-
-   return this._ui.getDOMElement();
-}
-  /**
-   * Resumes playback if a media item is paused or restarts an item from its beginning if
-   * the item has played and ended.
-   *
-   * @see {@link http://docs.videojs.com/Player.html#play}
-   */
-  play() {
-    if (!this.paused()) {
-      return;
-    }
-    if (this.ended()) {
-      // Restart the current item from the beginning
-      this._playSource(this.videojsPlayer.currentSource(), 0);
-    } else {
-      this._remotePlayerController.playOrPause();
-    }
-  }
-
-  /**
-   * Pauses playback if the player is not already paused and if the current media item
-   * has not ended yet.
-   *
-   * @see {@link http://docs.videojs.com/Player.html#pause}
-   */
-  pause() {
-    if (!this.paused() && this._remotePlayer.canPause) {
-      this._remotePlayerController.playOrPause();
-    }
-  }
-
-  /**
-   * Returns whether or not the player is "paused". Video.js' definition of "paused" is
-   * "playback paused" OR "not playing".
-   *
-   * @returns {boolean} true if playback is paused
-   * @see {@link http://docs.videojs.com/Player.html#paused}
-   */
-  paused() {
-    return (
-      this._remotePlayer.isPaused ||
-      this.ended() ||
-      this._remotePlayer.playerState === null
-    );
-  }
-
-  /**
-   * Stores the given source and begins playback, starting at the beginning
-   * of the media item.
-   *
-   * @param source {object} the source to store and play
-   * @see {@link http://docs.videojs.com/Player.html#src}
-   */
-  setSource(source) {
-    const mediaSession = this._getMediaSession();
-
-    if (
-      source.entity &&
-      mediaSession &&
-      mediaSession.media &&
-      mediaSession.media.entity === source.entity
-    ) {
-      // Skip setting the source if the `source` argument is the same as what's already
-      // been set. This `setSource` function calls `this._playSource` which sends a
-      // "load media" request to the Chromecast PlayerController. Because this function
-      // may be called multiple times in rapid succession with the same `source`
-      // argument, we need to de-duplicate calls with the same `source` argument to
-      // prevent overwhelming the Chromecast PlayerController with expensive "load
-      // media" requests, which it itself does not de-duplicate.
-      return;
-    }
-
-    this._playSource(source);
-  }
-
-  /**
-   * Generate `chrome.cast.media.Track` instance from `trackData`
-   *
-   * @param trackData {Object}
-   * @param trackData.src
-   * @param trackData.kind
-   * @param trackData.language
-   * @param id
-   * @returns {chrome.cast.media.Track}
-   * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.Track
-   */
-  generateTrack (trackData, id) {
-    var sub = new chrome.cast.media.Track(id, chrome.cast.media.TrackType.TEXT),
-      textTrackTypes;
-
-    textTrackTypes = {
-      subtitles: chrome.cast.media.TextTrackType.SUBTITLES,
-      captions: chrome.cast.media.TextTrackType.CAPTIONS,
-      descriptions: chrome.cast.media.TextTrackType.DESCRIPTIONS,
-      chapters: chrome.cast.media.TextTrackType.CHAPTERS,
-      metadata: chrome.cast.media.TextTrackType.METADATA,
-    };
-
-    sub.trackContentId = trackData.src;
-    sub.subtype = textTrackTypes[trackData.kind];
-    sub.name = trackData.language;
-    sub.language = trackData.language;
-    return sub;
-  }
-
-  /**
-   * _onChangeTrack
-   * @private
-   */
-  _onChangeTrack () {
-    var castSession =
-        cast.framework.CastContext.getInstance().getCurrentSession(),
-      media = castSession.getMediaSession(),
-      noop = function () {
-        /* noop */
-     }
-      index,
-      subtitles,
-      tracksInfoRequest,
-      i;
-
-    // TODO: investigate the case when we're trying to change track while there's no `media` (yet?)
-    if (castSession && media) {
-      index = [];
-      subtitles = this.videojsPlayer.remoteTextTracks();
-      for (i = 0; i < subtitles.length; i++) {
-        if (subtitles[i].mode === "showing") {
-          index = [i];
-        }
-      }
-      tracksInfoRequest = new chrome.cast.media.EditTracksInfoRequest(index);
-
-      media.editTracksInfo(tracksInfoRequest, noop, noop);
-    }
-  }
-
-  /**
-   * Plays the given source, beginning at an optional starting time.
-   *
-   * @private
-   * @param source {object} the source to play
-   * @param [startTime] The time to start playback at, in seconds
-   * @see {@link http://docs.videojs.com/Player.html#src}
-   */
-  _playSource(source, startTime) {
-    var castSession = this._getCastSession(),
-      loadSource = this._requestLoadSource(source),
-      mediaInfo = new chrome.cast.media.MediaInfo(
-        loadSource.src,
-        loadSource.type
-      ),
-      title = this._requestTitle(source),
-      subtitle = this._requestSubtitle(source),
-      customData = this._requestCustomData(source),
-      textTrackJsonTracks = this.videojsPlayer.textTracksJson_,
-      request,
-      castSessionObj,
-      i;
-
-    this.trigger("waiting");
-    this._clearSessionTimeout();
-
-    // if more then one source was load, load queue
-    if (loadSource.sources) {
-      this._queue = loadSource.sources;
-      const queueMediaInfo = loadSource.sources.map((queueItem) => {
-        const mediaInfoItem = new chrome.cast.media.MediaInfo(
-          queueItem.src,
-          queueItem.type
-        );
-
-        mediaInfoItem.entity = queueItem.entity;
-
-        mediaInfoItem.contentUrl = queueItem.src;
-        mediaInfoItem.metadata = new chrome.cast.media.GenericMediaMetadata();
-        mediaInfoItem.metadata.title = queueItem.title;
-        mediaInfoItem.duration = queueItem.duration;
-        mediaInfoItem.metadata.subtitle = queueItem.subtitle;
-        mediaInfoItem.streamType =
-          this.videojsPlayer.liveTracker &&
-          this.videojsPlayer.liveTracker.isLive()
-            ? chrome.cast.media.StreamType.LIVE
-            : chrome.cast.media.StreamType.BUFFERED;
-        mediaInfoItem.tracks = [];
-        mediaInfoItem.activeTrackIds = [];
-        return new chrome.cast.media.QueueItem(mediaInfoItem);
-      });
-
-      request = new chrome.cast.media.LoadRequest();
-      request.startIndex = loadSource.startIndex;
-      request.queueData = new chrome.cast.media.QueueData(
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        queueMediaInfo,
-        loadSource.startIndex,
-        loadSource.startTime
-      );
-    } else {
-      this._queue = null;
-      mediaInfo.entity = loadSource.entity;
-      mediaInfo.contentUrl = loadSource.src;
-      mediaInfo.contentType = loadSource.type;
-
-      mediaInfo.metadata = new chrome.cast.media.GenericMediaMetadata();
-      mediaInfo.metadata.metadataType = chrome.cast.media.MetadataType.GENERIC;
-      mediaInfo.metadata.title = title;
-      mediaInfo.metadata.subtitle = subtitle;
-      mediaInfo.streamType =
-        this.videojsPlayer.liveTracker &&
-        this.videojsPlayer.liveTracker.isLive()
-          ? chrome.cast.media.StreamType.LIVE
-          : chrome.cast.media.StreamType.BUFFERED;
-      mediaInfo.tracks = [];
-      mediaInfo.activeTrackIds = [];
-
-      for (i = 0; i < textTrackJsonTracks.length; i++) {
-        mediaInfo.tracks.push(this.generateTrack(textTrackJsonTracks[i], i));
-        if (textTrackJsonTracks[i].mode === "showing") {
-          mediaInfo.activeTrackIds.push(i);
-        }
-      }
-
-      if (customData) {
-        mediaInfo.customData = customData;
-      }
-      request = new chrome.cast.media.LoadRequest(mediaInfo);
-    }
-
-    request.autoplay = true;
-    request.currentTime =
-      startTime === undefined ? loadSource.startTime : startTime;
-    request.customData = this._requestCustomData();
-    if (loadSource.credentials) {
-      const credentialsData = new chrome.cast.CredentialsData(
-        loadSource.credentials
-      );
-
-      request = { ...request, ...credentialsData };
-    }
-    request = this._modifyLoadRequestFn(request);
-
-    this._isMediaLoading = true;
-    this._hasPlayedCurrentItem = false;
-    this._ui.updateTitle(title);
-    this._ui.updateSubtitle(subtitle);
-    castSessionObj = castSession.getSessionObj();
-    castSessionObj.loadMedia(
-      request,
-      this.onLoadSessionSuccess.bind(this),
-      this._triggerErrorEvent.bind(this)
-    );
-  }
-
-  /**
-   * onLoadSessionSuccess
-   */
-  onLoadSessionSuccess () {
-    if (!this._hasPlayedAnyItem) {
-      // `triggerReady` is required here to notify the Video.js player that the
-      // Tech has been initialized and is ready.
-      this.triggerReady();
-    }
-
-    this.trigger("loadstart");
-    this.trigger("loadeddata");
-    this.trigger("play");
-    this.trigger("playing");
-    this.videojsPlayer.hasStarted(true);
-    this._hasPlayedAnyItem = true;
-    this._isMediaLoading = false;
-    clearTimeout(this.playStateValidationTimeout);
-    this.playStateValidationTimeout = window.setTimeout(
-      this.validatePlayState.bind(this),
-      1000
-    );
-    this._getMediaSession().addUpdateListener(
-      this._onMediaSessionStatusChanged.bind(this)
-    );
-  }
-
-  /**
-   * Validate play state to make sure Chromecast and local player are in sync.
-   */
-  validatePlayState () {
-    var textTrackDisplay = this.videojsPlayer.getChild("TextTrackDisplay");
-
-    this._triggerTimeUpdateEvent();
-    this._onPlayerStateChanged();
-    this._onChangeTrack();
-
-    if (textTrackDisplay) {
-      textTrackDisplay.hide();
-    }
-  }
-
-  /**
-   * Manually updates the current time. The playback position will jump to the given time
-   * and continue playing if the item was playing when `setCurrentTime` was called, or
-   * remain paused if the item was paused.
-   *
-   * @param time {number} the playback time position to jump to
-   * @see {@link http://docs.videojs.com/Tech.html#setCurrentTime}
-   */
-  setCurrentTime (time) {
-    if (this.scrubbing()) {
-      this._scrubbingTime = time;
-      return false;
-    }
-    const duration = this.duration();
-
-    if (time > duration || !this._remotePlayer.canSeek) {
-      return;
-    }
-
-    // We need to delay the actual seeking, because when you
-    // scrub, videojs does pause() -> setCurrentTime() -> play()
-    // and that triggers a weird bug where the chromecast stops sending
-    // time_changed events.
-    this._isSeeking = true;
-    setTimeout(() => {
-      // Seeking to any place within (approximately) 1 second of the end of the item
-      // causes the Video.js player to get stuck in a BUFFERING state. To work around
-      // this, we only allow seeking to within 1 second of the end of an item.
-      this._remotePlayer.currentTime = Math.min(duration - 1, time);
-      this._remotePlayerController.seek();
-      this._isSeeking = false;
-   }, 500);
-    this._triggerTimeUpdateEvent();
-  }
-
-  seeking () {
-    return this._isSeeking;
-  }
-
-  scrubbing () {
-    return this._isScrubbing;
-  }
-
-  setScrubbing (newValue) {
-    if (newValue === true) {
-      this._scrubbingTime = this.currentTime();
-      this._isScrubbing = true;
-    } else {
-      this._isScrubbing = false;
-      this.setCurrentTime(this._scrubbingTime);
-    }
- }
-
-  /**
-   * Returns the current playback time position.
-   *
-   * @returns {number} the current playback time position
-   * @see {@link http://docs.videojs.com/Player.html#currentTime}
-   */
-  currentTime () {
-    // There is a brief period of time when Video.js has switched to the chromecast
-    // Tech, but chromecast has not yet loaded its first media item. During that time,
-    // Video.js calls this `currentTime` function to update its player UI. In that
-    // period, `this._remotePlayer.currentTime` will be 0 because the media has not
-    // loaded yet. To prevent the UI from using a 0 second currentTime, we use the
-    // currentTime passed in to the first media item that was provided to the Tech until
-    // chromecast plays its first item.
-    if (!this._hasPlayedAnyItem) {
-      return this._initialStartTime;
-    }
-    if (this.scrubbing() || this.seeking()) {
-      return this._scrubbingTime;
-    }
-    return this._remotePlayer.currentTime;
-  }
-
-  /**
-   * Returns the duration of the current media item, or `0` if the source is not set or
-   * if the duration of the item is not available from the Chromecast API yet.
-   *
-   * @returns {number} the duration of the current media item
-   * @see {@link http://docs.videojs.com/Player.html#duration}
-   */
-  duration () {
-    // There is a brief period of time when Video.js has switched to the chromecast
-    // Tech, but chromecast has not yet loaded its first media item. During that time,
-    // Video.js calls this `duration` function to update its player UI. In that period,
-    // `this._remotePlayer.duration` will be 0 because the media has not loaded yet. To
-    // prevent the UI from using a 0 second duration, we use the duration passed in to
-    // the first media item that was provided to the Tech until chromecast plays its
-    // first item.
-    if (!this._hasPlayedAnyItem) {
-      return this.videojsPlayer.duration();
-    }
-    return this._remotePlayer.duration;
-  }
-
-  /**
-   * Returns whether or not the current media item has finished playing. Returns `false`
-   * if a media item has not been loaded, has not been played, or has not yet finished
-   * playing.
-   *
-   * @returns {boolean} true if the current media item has finished playing
-   * @see {@link http://docs.videojs.com/Player.html#ended}
-   */
-  ended () {
-    var mediaSession = this._getMediaSession();
-
-    // Don't check for queues
-    // When handling a queue there are moments when mediaSession is null and current item has already finished
-    // and the new item is not started loading yet, which would end the session.
-    if (this._queue) {
-      return false;
-    }
-    if (!mediaSession && this._hasMediaSessionEnded && !this._isMediaLoading) {
-      return true;
-    }
-    return mediaSession
-      ? mediaSession.idleReason === chrome.cast.media.IdleReason.FINISHED
-      : false;
-  }
-
-  /**
-   * Returns the current volume level setting as a decimal number between `0` and `1`.
-   *
-   * @returns {number} the current volume level
-   * @see {@link http://docs.videojs.com/Player.html#volume}
-   */
-  volume () {
-    return this._remotePlayer.volumeLevel;
-  }
-
-  /**
-   * Sets the current volume level. Volume level is a decimal number between `0` and `1`,
-   * where `0` is muted and `1` is the loudest volume level.
-   *
-   * @param volumeLevel {number}
-   * @returns {number} the current volume level
-   * @see {@link http://docs.videojs.com/Player.html#volume}
-   */
-  setVolume (volumeLevel) {
-    this._remotePlayer.volumeLevel = volumeLevel;
-    this._remotePlayerController.setVolumeLevel();
-    // This event is triggered by the listener on
-    // `RemotePlayerEventType.VOLUME_LEVEL_CHANGED`, but waiting for that event to fire
-    // in response to calls to `setVolume` introduces noticeable lag in the updating of
-    // the player UI's volume slider bar, which makes user interaction with the volume
-    // slider choppy.
-    this._triggerVolumeChangeEvent();
-  }
-
-  /**
-   * Returns whether or not the player is currently muted.
-   *
-   * @returns {boolean} true if the player is currently muted
-   * @see {@link http://docs.videojs.com/Player.html#muted}
-   */
-  muted () {
-    return this._remotePlayer.isMuted;
-  }
-
-  /**
-   * Mutes or un-mutes the player. Does nothing if the player is currently muted and the
-   * `isMuted` parameter is true or if the player is not muted and `isMuted` is false.
-   *
-   * @param isMuted {boolean} whether or not the player should be muted
-   * @see {@link http://docs.videojs.com/Html5.html#setMuted} for an example
-   */
-  setMuted (isMuted) {
-    if (
-      (this._remotePlayer.isMuted && !isMuted) ||
-      (!this._remotePlayer.isMuted && isMuted)
-    ) {
-      this._remotePlayerController.muteOrUnmute();
-    }
-  }
-
-  /**
-   * Gets the URL to the current poster image.
-   *
-   * @returns {string} URL to the current poster image or `undefined` if none exists
-   * @see {@link http://docs.videojs.com/Player.html#poster}
-   */
-  poster () {
-    return this._ui.getPoster();
-  }
-
-  /**
-   * Sets the URL to the current poster image. The poster image shown in the Chromecast
-   * Tech UI view is updated with this new URL.
-   *
-   * @param poster {string} the URL to the new poster image
-   * @see {@link http://docs.videojs.com/Tech.html#setPoster}
-   */
-  setPoster (poster) {
-    this._ui.updatePoster(poster);
-  }
-
-  /**
-   * This function is "required" when implementing {@link external:Tech} and is supposed
-   * to return a mock
-   * {@link https://developer.mozilla.org/en-US/docs/Web/API/TimeRanges|TimeRanges}
-   * object that represents the portions of the current media item that have been
-   * buffered. However, the Chromecast API does not currently provide a way to determine
-   * how much the media item has buffered, so we always return `undefined`.
-   *
-   * Returning `undefined` is safe: the player will simply not display the buffer amount
-   * indicator in the scrubber UI.
-   *
-   * @returns {undefined} always returns `undefined`
-   * @see {@link http://docs.videojs.com/Player.html#buffered}
-   */
-  buffered () {
-    return undefined;
-  }
-
-  /**
-   * This function is "required" when implementing {@link external:Tech} and is supposed
-   * to return a mock
-   * {@link https://developer.mozilla.org/en-US/docs/Web/API/TimeRanges|TimeRanges}
-   * object that represents the portions of the current media item that has playable
-   * content. However, the Chromecast API does not currently provide a way to determine
-   * how much the media item has playable content, so we'll just assume the entire video
-   * is an available seek target.
-   *
-   * The risk here lies with live streaming, where there may exist a sliding window of
-   * playable content and seeking is only possible within the last X number of minutes,
-   * rather than for the entire video.
-   *
-   * Unfortunately we have no way of detecting when this is the case. Returning anything
-   * other than the full range of the video means that we lose the ability to seek during
-   * VOD.
-   *
-   * @returns {TimeRanges} always returns a `TimeRanges` object with one `TimeRange` that
-   * starts at `0` and ends at the `duration` of the current media item
-   * @see {@link http://docs.videojs.com/Player.html#seekable}
-   */
-  seekable () {
-    // TODO Investigate if there's a way to detect if the source is live, so that we can
-    // possibly adjust the seekable `TimeRanges` accordingly.
-    return this.videojs.createTimeRange(0, this.duration());
-  }
-
-  /**
-   * Returns whether the native media controls should be shown (`true`) or hidden
-   * (`false`). Not applicable to this Tech.
-   *
-   * @returns {boolean} always returns `false`
-   * @see {@link http://docs.videojs.com/Html5.html#controls} for an example
-   */
-  controls () {
-    return false;
-  }
-
-  /**
-   * Returns whether or not the browser should show the player "inline" (non-fullscreen)
-   * by default. This function always returns true to tell the browser that non-
-   * fullscreen playback is preferred.
-   *
-   * @returns {boolean} always returns `true`
-   * @see {@link http://docs.videojs.com/Html5.html#playsinline} for an example
-   */
-  playsinline () {
-    return true;
-  }
-
-  /**
-   * Returns whether or not fullscreen is supported by this Tech. Always returns `true`
-   * because fullscreen is always supported.
-   *
-   * @returns {boolean} always returns `true`
-   * @see {@link http://docs.videojs.com/Html5.html#supportsFullScreen} for an example
-   */
-  supportsFullScreen () {
-    return true;
-  }
-
-  /**
-   * Sets a flag that determines whether or not the media should automatically begin
-   * playing on page load. This is not supported because a Chromecast session must be
-   * initiated by casting via the casting menu and cannot autoplay.
-   *
-   * @see {@link http://docs.videojs.com/Html5.html#setAutoplay} for an example
-   */
-  setAutoplay () {
-    // Not supported
-  }
-
-  /**
-   * @returns {number} the chromecast player's playback rate, if available. Otherwise,
-   * the return value defaults to `1`.
-   */
-  playbackRate () {
-    var mediaSession = this._getMediaSession();
-
-    return mediaSession ? mediaSession.playbackRate : 1;
-  }
-
-  /**
-   * Does nothing. Changing the playback rate is not supported.
-   */
-  setPlaybackRate () {
-    // Not supported
-  }
-
-  /**
-   * Does nothing. Satisfies calls to the missing preload method.
-   */
-  preload () {
-    // Not supported
-  }
-
-  /**
-   * Causes the Tech to begin loading the current source. `load` is not supported in this
-   * ChromecastTech because setting the source on the `Chromecast` automatically causes
-   * it to begin loading.
-   */
-  load () {
-    // Not supported
-  }
-
-  /**
-   * Gets the Chromecast equivalent of HTML5 Media Element's `readyState`.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/readyState
-   */
-  readyState () {
-    if (
-      this._remotePlayer.playerState === "IDLE" ||
-      this._remotePlayer.playerState === "BUFFERING"
-    ) {
-      return 0; // HAVE_NOTHING
-    }
-    return 4;
-  }
-
-  /**
-   * Wires up event listeners for
-   * [RemotePlayerController](https://developers.google.com/cast/docs/reference/chrome/cast.framework.RemotePlayerController)
-   * events.
-   *
-   * @private
-   */
-  _listenToPlayerControllerEvents () {
-    var eventTypes = cast.framework.RemotePlayerEventType;
-
-    this._addEventListener(
-      this._remotePlayerController,
-      eventTypes.MEDIA_INFO_CHANGED,
-      () => {
-        if (typeof this._getMediaSession().activeTrackIds[0] === "number") {
-          const id = this._getMediaSession().activeTrackIds[0];
-
-          const tracks = this._getMediaSession().media.tracks;
-
-          const name = tracks[id].name;
-
-          this._onChangeSubtitleTrack({ name });
-        } else {
-          this._onChangeSubtitleTrack(null);
-        }
-     }
-      this
-    );
-    this._addEventListener(
-      this._remotePlayerController,
-      eventTypes.PLAYER_STATE_CHANGED,
-      this._onPlayerStateChanged,
-      this
-    );
-    this._addEventListener(
-      this._remotePlayerController,
-      eventTypes.VOLUME_LEVEL_CHANGED,
-      this._triggerVolumeChangeEvent,
-      this
-    );
-    this._addEventListener(
-      this._remotePlayerController,
-      eventTypes.IS_MUTED_CHANGED,
-      this._triggerVolumeChangeEvent,
-      this
-    );
-    this._addEventListener(
-      this._remotePlayerController,
-      eventTypes.CURRENT_TIME_CHANGED,
-      this._triggerTimeUpdateEvent,
-      this
-    );
-    this._addEventListener(
-      this._remotePlayerController,
-      eventTypes.DURATION_CHANGED,
-      this._triggerDurationChangeEvent,
-      this
-    );
-    // If any subtitles were loaded on cast receiver side,
-    // check if they exist on web player side, if not add them
-    this._addEventListener(
-      this._remotePlayerController,
-      eventTypes.MEDIA_INFO_CHANGED,
-      (event) => {
-        this.videojsPlayer.remoteTextTracks();
-        const alreadyLoadedTracks =
-          this.videojsPlayer.remoteTextTracks().tracks_;
-
-        const player = this.videojsPlayer;
-
-        if (event.value && event.value.tracks) {
-          event.value.tracks.forEach(function (track) {
-            const isAlreadyLoaded = alreadyLoadedTracks.some(function (
-              alreadyLoadedTrack
-            ) {
-              return alreadyLoadedTrack.id === track.name;
-            });
-
-            if (!isAlreadyLoaded) {
-              track.id = track.name;
-              player.addRemoteTextTrack(track);
-            }
-          });
-        }
-      }
-    );
-    this._addEventListener(
-      this._remotePlayerController,
-      eventTypes.MEDIA_INFO_CHANGED,
-      this._handleMediaInfoChangeEvent,
-      this
-    );
-  }
-
-  /**
-   * Registers an event listener on the given target object. Because many objects in the
-   * Chromecast API are either singletons or must be shared between instances of
-   * `ChromecastTech` for the lifetime of the player, we must unbind the listeners when
-   * this Tech instance is destroyed to prevent memory leaks. To do that, we need to keep
-   * a reference to listeners that are added to global objects so that we can use those
-   * references to remove the listener when this Tech is destroyed.
-   *
-   * @param target {object} the object to register the event listener on
-   * @param type {string} the name of the event
-   * @param callback {Function} the listener's callback function that executes when the
-   * event is emitted
-   * @param context {object} the `this` context to use when executing the `callback`
-   * @private
-   */
-  _addEventListener (target, type, callback, context) {
-    var listener;
-
-    listener = {
-      target: target,
-      type: type,
-      callback: callback,
-      context: context,
-      listener: callback.bind(context),
-    };
-    target.addEventListener(type, listener.listener);
-    this._eventListeners.push(listener);
-  }
-
-  /**
-   * _onDispose
-   * @private
-   */
-  _onDispose () {
-    var textTrackDisplay = this.videojsPlayer.getChild("TextTrackDisplay");
-
-    if (textTrackDisplay) {
-      textTrackDisplay.show();
-    }
-    clearTimeout(this.playStateValidationTimeout);
-    this._removeAllEventListeners();
-    // even with `stopCasting === false`, `endCurrentSession` *stops* casting
-    // this._getCastContext().endCurrentSession(/* stopCasting */ false);
-  }
-
-  /**
-   * Removes all event listeners that were registered with global objects during the
-   * lifetime of this Tech. See {@link _addEventListener} for more information about why
-   * this is necessary.
-   *
-   * @private
-   */
-  _removeAllEventListeners () {
-    while (this._eventListeners.length > 0) {
-      this._removeEventListener(this._eventListeners[0]);
-    }
-    this._eventListeners = [];
-  }
-
-  /**
-   * Removes a single event listener that was registered with global objects during the
-   * lifetime of this Tech. See {@link _addEventListener} for more information about why
-   * this is necessary.
-   *
-   * @private
-   */
-  _removeEventListener(listener) {
-    var index = -1,
-      pass = false,
-      i;
-
-    listener.target.removeEventListener(listener.type, listener.listener);
-
-    for (i = 0; i < this._eventListeners.length; i++) {
-      pass =
-        this._eventListeners[i].target === listener.target &&
-        this._eventListeners[i].type === listener.type &&
-        this._eventListeners[i].callback === listener.callback &&
-        this._eventListeners[i].context === listener.context;
-
-      if (pass) {
-        index = i;
-        break;
-      }
-    }
-
-    if (index !== -1) {
-      this._eventListeners.splice(index, 1);
-    }
-  }
-
-  /**
-   * Handles Chromecast player state change events. The player may "change state" when
-   * paused, played, buffering, etc.
-   *
-   * @private
-   */
-  _onPlayerStateChanged () {
-    var states = chrome.cast.media.PlayerState,
-      playerState = this._remotePlayer.playerState;
-
-    if (playerState === states.PLAYING) {
-      this._hasPlayedCurrentItem = true;
-      this.trigger("play");
-      this.trigger("playing");
-    } else if (playerState === states.PAUSED) {
-      this.trigger("pause");
-    } else if (
-      (playerState === states.IDLE && this.ended()) ||
-      (playerState === null && this._hasPlayedCurrentItem)
-    ) {
-      this._hasPlayedCurrentItem = false;
-      this._closeSessionOnTimeout();
-      this.trigger("ended");
-      this._triggerTimeUpdateEvent();
-    } else if (playerState === states.BUFFERING) {
-      this.trigger("waiting");
-    }
-  }
-
-  /**
-   * Handles Chromecast MediaSession state change events. The only property sent to this
-   * event is whether the session is alive. This is useful for determining if an item has
-   * ended as the MediaSession will fire this event with `false` then be immediately
-   * destroyed. This means that we cannot trust `idleReason` to show whether an item has
-   * ended since we may no longer have access to the MediaSession.
-   *
-   * @private
-   */
-  _onMediaSessionStatusChanged (isAlive) {
-    this._hasMediaSessionEnded = !!isAlive;
-  }
-
-  /**
-   * Ends the session after a certain number of seconds of inactivity.
-   *
-   * If the Chromecast player is in the "IDLE" state after an item has ended, and no
-   * further items are queued up to play, the session is considered inactive. Once a
-   * period of time (currently 10 seconds) has elapsed with no activity, we manually end
-   * the session to prevent long periods of a blank Chromecast screen that is shown at
-   * the end of item playback.
-   *
-   * @private
-   */
-  _closeSessionOnTimeout () {
-    // Ensure that there's never more than one session timeout active
-    this._clearSessionTimeout();
-    this._sessionTimeoutID = setTimeout(
-      function () {
-        var castSession = this._getCastSession();
-
-        if (castSession) {
-          castSession.endSession(true);
-        }
-        this._clearSessionTimeout();
-      }.bind(this),
-      SESSION_TIMEOUT
-    );
-  }
-
-  /**
-   * Stops the timeout that is waiting during a period of inactivity in order to close
-   * the session.
-   *
-   * @private
-   * @see _closeSessionOnTimeout
-   */
-  _clearSessionTimeout () {
-    if (this._sessionTimeoutID) {
-      clearTimeout(this._sessionTimeoutID);
-      this._sessionTimeoutID = false;
-    }
-  }
-
-  /**
-   * @private
-   * @return {object} the current CastContext, if one exists
-   */
-  _getCastContext() {
-    return this._chromecastSessionManager.getCastContext();
- }
-
-  /**
-   * @private
-   * @return {object} the current CastSession, if one exists
-   */
-  _getCastSession() {
-    return this._getCastContext().getCurrentSession();
- }
-
-  /**
-   * @private
-   * @return {object} the current MediaSession, if one exists
-   * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.Media
-   */
-  _getMediaSession() {
-    var castSession = this._getCastSession();
-
-    return castSession ? castSession.getMediaSession() : null;
- }
-
-  /**
-   * Triggers a 'volumechange' event
-   * @private
-   * @see http://docs.videojs.com/Player.html#event:volumechange
-   */
-  _triggerVolumeChangeEvent() {
-    this.trigger("volumechange");
- }
-
-  /**
-   * Triggers a 'timeupdate' event
-   * @private
-   * @see http://docs.videojs.com/Player.html#event:timeupdate
-   */
-  _triggerTimeUpdateEvent() {
-    this.trigger("timeupdate");
- }
-
-  /**
-   * Triggers a 'durationchange' event
-   * @private
-   * @see http://docs.videojs.com/Player.html#event:durationchange
-   */
-  _triggerDurationChangeEvent() {
-    this.trigger("durationchange");
- }
-
-  /**
-   * @private
-   */
-  _handleMediaInfoChangeEvent: function (event) {
-    this._requestQueueItemChange(event);
- }
-
-  /**
-   * Triggers an 'error' event
-   * @private
-   * @see http://docs.videojs.com/Player.html#event:error
-   */
-  _triggerErrorEvent() {
-    this.trigger("error");
- }
-};
-
-/**
- * Registers the ChromecastTech Tech with Video.js. Calls {@link
- * http://docs.videojs.com/Tech.html#.registerTech}, which will add a Tech called
- * `chromecast` to the list of globally registered Video.js Tech implementations.
- *
- * [Video.js Tech](http://docs.videojs.com/Tech.html) are initialized and used
- * automatically by Video.js Player instances. Whenever a new source is set on the player,
- * the player iterates through the list of available Tech to determine which to use to
- * play the source.
- *
- * @param videojs {object} A reference to
- * {@link http://docs.videojs.com/module-videojs.html|Video.js}
- * @see http://docs.videojs.com/Tech.html#.registerTech
- */
 module.exports = function (videojs) {
   var Tech = videojs.getComponent("Tech"),
     SESSION_TIMEOUT = 10 * 1000; // milliseconds
@@ -1193,24 +55,36 @@ module.exports = function (videojs) {
       this.featuresNativeTextTracks = false;
       this.featuresNativeAudioTracks = false;
       this.featuresNativeVideoTracks = false;
+      var mediaSession, textTrackDisplay, subclass;
 
       // Give ChromecastTech class instances a reference to videojs
       this.videojs = videojs;
       this._eventListeners = [];
-
+      this.options = options;
       this.videojsPlayer = this.videojs(options.playerId);
       this._chromecastSessionManager =
         this.videojsPlayer.chromecastSessionManager;
 
+      // We have to initialize the UI here, before calling super.constructor
+      // because the constructor calls `createEl`, which references `this._ui`.
+      this._ui = new ChromecastTechUI();
       this._ui.updatePoster(this.videojsPlayer.poster());
+
+      // Call the super class' constructor function
+      subclass = this.constructor.super_.apply(this, arguments);
 
       this._remotePlayer = this._chromecastSessionManager.getRemotePlayer();
       this._remotePlayerController =
         this._chromecastSessionManager.getRemotePlayerController();
       this._listenToPlayerControllerEvents();
-      this.on("dispose", this._removeAllEventListeners.bind(this));
+      this.on("dispose", this._onDispose.bind(this));
 
       this._hasPlayedAnyItem = false;
+      this._onChangeSubtitleTrack =
+        options.onChangeSubtitleTrackFn ||
+        function () {
+          /* noop */
+        };
       this._requestTitle =
         options.requestTitleFn ||
         function () {
@@ -1221,22 +95,62 @@ module.exports = function (videojs) {
         function () {
           /* noop */
         };
+      this._requestQueueItemChange =
+        options.requestQueueItemChangeFn ||
+        function () {
+          /* noop */
+        };
       this._requestCustomData =
         options.requestCustomDataFn ||
         function () {
           /* noop */
         };
-      // See `currentTime` function
-      this._initialStartTime = options.startTime || 0;
+      this._modifyLoadRequestFn =
+        options.modifyLoadRequestFn ||
+        function () {
+          /* noop */
+        };
+      this._requestLoadSource =
+        options.requestLoadSourceFn ||
+        function (source) {
+          return source;
+        };
+      const loadSource = this._requestLoadSource(options.source);
 
-      this._playSource(options.source, this._initialStartTime);
+      // See `currentTime` function
+      this._initialStartTime =
+        options.startTime === undefined
+          ? loadSource.startTime || 0
+          : options.startTime;
+      this._isScrubbing = false;
+      this._isSeeking = false;
+      this._scrubbingTime = this._initialStartTime;
+
+      mediaSession = this._getMediaSession();
+      if (
+        mediaSession &&
+        mediaSession.media &&
+        mediaSession.media.entity === loadSource.entity
+      ) {
+        this.onLoadSessionSuccess();
+      } else {
+        this._playSource(options.source);
+      }
+
       this.ready(
         function () {
           this.setMuted(options.muted);
         }.bind(this)
       );
-    }
+      this.videojsPlayer
+        .remoteTextTracks()
+        .on("change", this._onChangeTrack.bind(this));
+      textTrackDisplay = this.videojsPlayer.getChild("TextTrackDisplay");
 
+      if (textTrackDisplay) {
+        textTrackDisplay.hide();
+      }
+    }
     /**
      * Creates a DOMElement that Video.js displays in its player UI while this Tech is
      * active.
@@ -1251,10 +165,9 @@ module.exports = function (videojs) {
 
       return this._ui.getDOMElement();
     }
-
     /**
-     * Resumes playback if a media item is paused or restarts an item from
-     * its beginning if the item has played and ended.
+     * Resumes playback if a media item is paused or restarts an item from its beginning if
+     * the item has played and ended.
      *
      * @see {@link http://docs.videojs.com/Player.html#play}
      */
@@ -1262,9 +175,9 @@ module.exports = function (videojs) {
       if (!this.paused()) {
         return;
       }
-      if (this.ended() && !this._isMediaLoading) {
+      if (this.ended()) {
         // Restart the current item from the beginning
-        this._playSource({ src: this.videojsPlayer.src() }, 0);
+        this._playSource(this.videojsPlayer.currentSource(), 0);
       } else {
         this._remotePlayerController.playOrPause();
       }
@@ -1283,8 +196,8 @@ module.exports = function (videojs) {
     }
 
     /**
-     * Returns whether or not the player is "paused". Video.js'
-     * definition of "paused" is "playback paused" OR "not playing".
+     * Returns whether or not the player is "paused". Video.js' definition of "paused" is
+     * "playback paused" OR "not playing".
      *
      * @returns {boolean} true if playback is paused
      * @see {@link http://docs.videojs.com/Player.html#paused}
@@ -1305,28 +218,86 @@ module.exports = function (videojs) {
      * @see {@link http://docs.videojs.com/Player.html#src}
      */
     setSource(source) {
+      const mediaSession = this._getMediaSession();
+
       if (
-        this._currentSource &&
-        this._currentSource.src === source.src &&
-        this._currentSource.type === source.type
+        source.entity &&
+        mediaSession &&
+        mediaSession.media &&
+        mediaSession.media.entity === source.entity
       ) {
-        // Skip setting the source if the `source` argument is the
-        // same as what's already been set. This `setSource` function
-        // calls `this._playSource` which sends a "load media" request
-        // to the Chromecast PlayerController. Because this function
+        // Skip setting the source if the `source` argument is the same as what's already
+        // been set. This `setSource` function calls `this._playSource` which sends a
+        // "load media" request to the Chromecast PlayerController. Because this function
         // may be called multiple times in rapid succession with the same `source`
         // argument, we need to de-duplicate calls with the same `source` argument to
         // prevent overwhelming the Chromecast PlayerController with expensive "load
         // media" requests, which it itself does not de-duplicate.
         return;
       }
-      // We cannot use `this.videojsPlayer.currentSource()` because the
-      // value returned by that function is not the same as what's returned
-      // by the Video.js Player's middleware after they are run. Also, simply
-      // using `this.videojsPlayer.src()` does not include mimetype information
-      // which we pass to the Chromecast player.
-      this._currentSource = source;
-      this._playSource(source, 0);
+
+      this._playSource(source);
+    }
+
+    /**
+     * Generate `chrome.cast.media.Track` instance from `trackData`
+     *
+     * @param trackData {Object}
+     * @param trackData.src
+     * @param trackData.kind
+     * @param trackData.language
+     * @param id
+     * @returns {chrome.cast.media.Track}
+     * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.Track
+     */
+    generateTrack(trackData, id) {
+      var sub = new chrome.cast.media.Track(
+          id,
+          chrome.cast.media.TrackType.TEXT
+        ),
+        textTrackTypes;
+
+      textTrackTypes = {
+        subtitles: chrome.cast.media.TextTrackType.SUBTITLES,
+        captions: chrome.cast.media.TextTrackType.CAPTIONS,
+        descriptions: chrome.cast.media.TextTrackType.DESCRIPTIONS,
+        chapters: chrome.cast.media.TextTrackType.CHAPTERS,
+        metadata: chrome.cast.media.TextTrackType.METADATA,
+      };
+
+      sub.trackContentId = trackData.src;
+      sub.subtype = textTrackTypes[trackData.kind];
+      sub.name = trackData.language;
+      sub.language = trackData.language;
+      return sub;
+    }
+
+    /**
+     * _onChangeTrack
+     * @private
+     */
+    _onChangeTrack() {
+      var castSession =
+          cast.framework.CastContext.getInstance().getCurrentSession(),
+        media = castSession.getMediaSession(),
+        noop = function () {
+          /* noop */
+        };
+      index, subtitles, tracksInfoRequest, i;
+
+      // TODO: investigate the case when we're trying to change track while there's no `media` (yet?)
+      if (castSession && media) {
+        index = [];
+        subtitles = this.videojsPlayer.remoteTextTracks();
+        for (i = 0; i < subtitles.length; i++) {
+          if (subtitles[i].mode === "showing") {
+            index = [i];
+          }
+        }
+        tracksInfoRequest = new chrome.cast.media.EditTracksInfoRequest(index);
+
+        media.editTracksInfo(tracksInfoRequest, noop, noop);
+      }
     }
 
     /**
@@ -1339,83 +310,209 @@ module.exports = function (videojs) {
      */
     _playSource(source, startTime) {
       var castSession = this._getCastSession(),
-        mediaInfo = new chrome.cast.media.MediaInfo(source.src, source.type),
+        loadSource = this._requestLoadSource(source),
+        mediaInfo = new chrome.cast.media.MediaInfo(
+          loadSource.src,
+          loadSource.type
+        ),
         title = this._requestTitle(source),
         subtitle = this._requestSubtitle(source),
-        poster = this.poster(),
         customData = this._requestCustomData(source),
-        request;
+        textTrackJsonTracks = this.videojsPlayer.textTracksJson_,
+        request,
+        castSessionObj,
+        i;
 
       this.trigger("waiting");
       this._clearSessionTimeout();
 
-      mediaInfo.metadata = new chrome.cast.media.GenericMediaMetadata();
-      mediaInfo.metadata.metadataType = chrome.cast.media.MetadataType.GENERIC;
-      mediaInfo.metadata.title = title;
-      mediaInfo.metadata.subtitle = subtitle;
-      mediaInfo.streamType =
-        this.videojsPlayer.liveTracker &&
-        this.videojsPlayer.liveTracker.isLive()
-          ? chrome.cast.media.StreamType.LIVE
-          : chrome.cast.media.StreamType.BUFFERED;
+      // if more then one source was load, load queue
+      if (loadSource.sources) {
+        this._queue = loadSource.sources;
+        const queueMediaInfo = loadSource.sources.map((queueItem) => {
+          const mediaInfoItem = new chrome.cast.media.MediaInfo(
+            queueItem.src,
+            queueItem.type
+          );
 
-      if (poster) {
-        mediaInfo.metadata.images = [{ url: poster }];
+          mediaInfoItem.entity = queueItem.entity;
+
+          mediaInfoItem.contentUrl = queueItem.src;
+          mediaInfoItem.metadata = new chrome.cast.media.GenericMediaMetadata();
+          mediaInfoItem.metadata.title = queueItem.title;
+          mediaInfoItem.duration = queueItem.duration;
+          mediaInfoItem.metadata.subtitle = queueItem.subtitle;
+          mediaInfoItem.streamType =
+            this.videojsPlayer.liveTracker &&
+            this.videojsPlayer.liveTracker.isLive()
+              ? chrome.cast.media.StreamType.LIVE
+              : chrome.cast.media.StreamType.BUFFERED;
+          mediaInfoItem.tracks = [];
+          mediaInfoItem.activeTrackIds = [];
+          return new chrome.cast.media.QueueItem(mediaInfoItem);
+        });
+
+        request = new chrome.cast.media.LoadRequest();
+        request.startIndex = loadSource.startIndex;
+        request.queueData = new chrome.cast.media.QueueData(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          queueMediaInfo,
+          loadSource.startIndex,
+          loadSource.startTime
+        );
+      } else {
+        this._queue = null;
+        mediaInfo.entity = loadSource.entity;
+        mediaInfo.contentUrl = loadSource.src;
+        mediaInfo.contentType = loadSource.type;
+
+        mediaInfo.metadata = new chrome.cast.media.GenericMediaMetadata();
+        mediaInfo.metadata.metadataType =
+          chrome.cast.media.MetadataType.GENERIC;
+        mediaInfo.metadata.title = title;
+        mediaInfo.metadata.subtitle = subtitle;
+        mediaInfo.streamType =
+          this.videojsPlayer.liveTracker &&
+          this.videojsPlayer.liveTracker.isLive()
+            ? chrome.cast.media.StreamType.LIVE
+            : chrome.cast.media.StreamType.BUFFERED;
+        mediaInfo.tracks = [];
+        mediaInfo.activeTrackIds = [];
+
+        for (i = 0; i < textTrackJsonTracks.length; i++) {
+          mediaInfo.tracks.push(this.generateTrack(textTrackJsonTracks[i], i));
+          if (textTrackJsonTracks[i].mode === "showing") {
+            mediaInfo.activeTrackIds.push(i);
+          }
+        }
+
+        if (customData) {
+          mediaInfo.customData = customData;
+        }
+        request = new chrome.cast.media.LoadRequest(mediaInfo);
       }
-      if (customData) {
-        mediaInfo.customData = customData;
-      }
 
-      this._ui.updateTitle(title);
-      this._ui.updateSubtitle(subtitle);
-
-      request = new chrome.cast.media.LoadRequest(mediaInfo);
       request.autoplay = true;
-      request.currentTime = startTime;
+      request.currentTime =
+        startTime === undefined ? loadSource.startTime : startTime;
+      request.customData = this._requestCustomData();
+      if (loadSource.credentials) {
+        const credentialsData = new chrome.cast.CredentialsData(
+          loadSource.credentials
+        );
+
+        request = { ...request, ...credentialsData };
+      }
+      request = this._modifyLoadRequestFn(request);
 
       this._isMediaLoading = true;
       this._hasPlayedCurrentItem = false;
-      castSession.loadMedia(request).then(
-        function () {
-          if (!this._hasPlayedAnyItem) {
-            // `triggerReady` is required here to notify the Video.js
-            // player that the Tech has been initialized and is ready.
-            this.triggerReady();
-          }
-          this.trigger("loadstart");
-          this.trigger("loadeddata");
-          this.trigger("play");
-          this.trigger("playing");
-          this._hasPlayedAnyItem = true;
-          this._isMediaLoading = false;
-          this._getMediaSession().addUpdateListener(
-            this._onMediaSessionStatusChanged.bind(this)
-          );
-        }.bind(this),
+      this._ui.updateTitle(title);
+      this._ui.updateSubtitle(subtitle);
+      castSessionObj = castSession.getSessionObj();
+      castSessionObj.loadMedia(
+        request,
+        this.onLoadSessionSuccess.bind(this),
         this._triggerErrorEvent.bind(this)
       );
     }
 
     /**
-     * Manually updates the current time. The playback position will jump to
-     * the given time and continue playing if the item was playing when `setCurrentTime`
-     * was called, or remain paused if the item was paused.
+     * onLoadSessionSuccess
+     */
+    onLoadSessionSuccess() {
+      if (!this._hasPlayedAnyItem) {
+        // `triggerReady` is required here to notify the Video.js player that the
+        // Tech has been initialized and is ready.
+        this.triggerReady();
+      }
+
+      this.trigger("loadstart");
+      this.trigger("loadeddata");
+      this.trigger("play");
+      this.trigger("playing");
+      this.videojsPlayer.hasStarted(true);
+      this._hasPlayedAnyItem = true;
+      this._isMediaLoading = false;
+      clearTimeout(this.playStateValidationTimeout);
+      this.playStateValidationTimeout = window.setTimeout(
+        this.validatePlayState.bind(this),
+        1000
+      );
+      this._getMediaSession().addUpdateListener(
+        this._onMediaSessionStatusChanged.bind(this)
+      );
+    }
+
+    /**
+     * Validate play state to make sure Chromecast and local player are in sync.
+     */
+    validatePlayState() {
+      var textTrackDisplay = this.videojsPlayer.getChild("TextTrackDisplay");
+
+      this._triggerTimeUpdateEvent();
+      this._onPlayerStateChanged();
+      this._onChangeTrack();
+
+      if (textTrackDisplay) {
+        textTrackDisplay.hide();
+      }
+    }
+
+    /**
+     * Manually updates the current time. The playback position will jump to the given time
+     * and continue playing if the item was playing when `setCurrentTime` was called, or
+     * remain paused if the item was paused.
      *
      * @param time {number} the playback time position to jump to
      * @see {@link http://docs.videojs.com/Tech.html#setCurrentTime}
      */
     setCurrentTime(time) {
-      var duration = this.duration();
+      if (this.scrubbing()) {
+        this._scrubbingTime = time;
+        return false;
+      }
+      const duration = this.duration();
 
       if (time > duration || !this._remotePlayer.canSeek) {
         return;
       }
-      // Seeking to any place within (approximately) 1 second of the end of the item
-      // causes the Video.js player to get stuck in a BUFFERING state. To work around
-      // this, we only allow seeking to within 1 second of the end of an item.
-      this._remotePlayer.currentTime = Math.min(duration - 1, time);
-      this._remotePlayerController.seek();
+
+      // We need to delay the actual seeking, because when you
+      // scrub, videojs does pause() -> setCurrentTime() -> play()
+      // and that triggers a weird bug where the chromecast stops sending
+      // time_changed events.
+      this._isSeeking = true;
+      setTimeout(() => {
+        // Seeking to any place within (approximately) 1 second of the end of the item
+        // causes the Video.js player to get stuck in a BUFFERING state. To work around
+        // this, we only allow seeking to within 1 second of the end of an item.
+        this._remotePlayer.currentTime = Math.min(duration - 1, time);
+        this._remotePlayerController.seek();
+        this._isSeeking = false;
+      }, 500);
       this._triggerTimeUpdateEvent();
+    }
+
+    seeking() {
+      return this._isSeeking;
+    }
+
+    scrubbing() {
+      return this._isScrubbing;
+    }
+
+    setScrubbing(newValue) {
+      if (newValue === true) {
+        this._scrubbingTime = this.currentTime();
+        this._isScrubbing = true;
+      } else {
+        this._isScrubbing = false;
+        this.setCurrentTime(this._scrubbingTime);
+      }
     }
 
     /**
@@ -1426,35 +523,36 @@ module.exports = function (videojs) {
      */
     currentTime() {
       // There is a brief period of time when Video.js has switched to the chromecast
-      // Tech, but chromecast has not yet loaded its first media item. During
-      // that time, Video.js calls this `currentTime` function to update
-      // its player UI. In that period, `this._remotePlayer.currentTime`
-      // will be 0 because the media has not loaded yet. To prevent the
-      // UI from using a 0 second currentTime, we use the currentTime passed
-      // in to the first media item that was provided to the Tech until
+      // Tech, but chromecast has not yet loaded its first media item. During that time,
+      // Video.js calls this `currentTime` function to update its player UI. In that
+      // period, `this._remotePlayer.currentTime` will be 0 because the media has not
+      // loaded yet. To prevent the UI from using a 0 second currentTime, we use the
+      // currentTime passed in to the first media item that was provided to the Tech until
       // chromecast plays its first item.
       if (!this._hasPlayedAnyItem) {
         return this._initialStartTime;
+      }
+      if (this.scrubbing() || this.seeking()) {
+        return this._scrubbingTime;
       }
       return this._remotePlayer.currentTime;
     }
 
     /**
-     * Returns the duration of the current media item, or `0` if the source
-     * is not set or if the duration of the item is not available from the
-     * Chromecast API yet.
+     * Returns the duration of the current media item, or `0` if the source is not set or
+     * if the duration of the item is not available from the Chromecast API yet.
      *
      * @returns {number} the duration of the current media item
      * @see {@link http://docs.videojs.com/Player.html#duration}
      */
     duration() {
       // There is a brief period of time when Video.js has switched to the chromecast
-      // Tech, but chromecast has not yet loaded its first media item.
-      // During that time, Video.js calls this `duration` function to update its player
-      // UI. In that period, `this._remotePlayer.duration` will be 0 because the media
-      // has not loaded yet. To prevent the UI from using a 0 second duration, we
-      // use the duration passed in to the first media item that was provided to
-      // the Tech until chromecast plays its first item.
+      // Tech, but chromecast has not yet loaded its first media item. During that time,
+      // Video.js calls this `duration` function to update its player UI. In that period,
+      // `this._remotePlayer.duration` will be 0 because the media has not loaded yet. To
+      // prevent the UI from using a 0 second duration, we use the duration passed in to
+      // the first media item that was provided to the Tech until chromecast plays its
+      // first item.
       if (!this._hasPlayedAnyItem) {
         return this.videojsPlayer.duration();
       }
@@ -1462,9 +560,9 @@ module.exports = function (videojs) {
     }
 
     /**
-     * Returns whether or not the current media item has finished playing.
-     * Returns `false` if a media item has not been loaded, has not been played,
-     * or has not yet finished playing.
+     * Returns whether or not the current media item has finished playing. Returns `false`
+     * if a media item has not been loaded, has not been played, or has not yet finished
+     * playing.
      *
      * @returns {boolean} true if the current media item has finished playing
      * @see {@link http://docs.videojs.com/Player.html#ended}
@@ -1472,10 +570,19 @@ module.exports = function (videojs) {
     ended() {
       var mediaSession = this._getMediaSession();
 
-      if (!mediaSession && this._hasMediaSessionEnded) {
+      // Don't check for queues
+      // When handling a queue there are moments when mediaSession is null and current item has already finished
+      // and the new item is not started loading yet, which would end the session.
+      if (this._queue) {
+        return false;
+      }
+      if (
+        !mediaSession &&
+        this._hasMediaSessionEnded &&
+        !this._isMediaLoading
+      ) {
         return true;
       }
-
       return mediaSession
         ? mediaSession.idleReason === chrome.cast.media.IdleReason.FINISHED
         : false;
@@ -1492,8 +599,8 @@ module.exports = function (videojs) {
     }
 
     /**
-     * Sets the current volume level. Volume level is a decimal number
-     * between `0` and `1`, where `0` is muted and `1` is the loudest volume level.
+     * Sets the current volume level. Volume level is a decimal number between `0` and `1`,
+     * where `0` is muted and `1` is the loudest volume level.
      *
      * @param volumeLevel {number}
      * @returns {number} the current volume level
@@ -1503,10 +610,10 @@ module.exports = function (videojs) {
       this._remotePlayer.volumeLevel = volumeLevel;
       this._remotePlayerController.setVolumeLevel();
       // This event is triggered by the listener on
-      // `RemotePlayerEventType.VOLUME_LEVEL_CHANGED`, but waiting for
-      // that event to fire in response to calls to `setVolume` introduces
-      // noticeable lag in the updating of the player UI's volume slider bar,
-      // which makes user interaction with the volume slider choppy.
+      // `RemotePlayerEventType.VOLUME_LEVEL_CHANGED`, but waiting for that event to fire
+      // in response to calls to `setVolume` introduces noticeable lag in the updating of
+      // the player UI's volume slider bar, which makes user interaction with the volume
+      // slider choppy.
       this._triggerVolumeChangeEvent();
     }
 
@@ -1521,9 +628,8 @@ module.exports = function (videojs) {
     }
 
     /**
-     * Mutes or un-mutes the player. Does nothing if the player is currently
-     * muted and the `isMuted` parameter is true or if the player is not muted and
-     * `isMuted` is false.
+     * Mutes or un-mutes the player. Does nothing if the player is currently muted and the
+     * `isMuted` parameter is true or if the player is not muted and `isMuted` is false.
      *
      * @param isMuted {boolean} whether or not the player should be muted
      * @see {@link http://docs.videojs.com/Html5.html#setMuted} for an example
@@ -1548,8 +654,8 @@ module.exports = function (videojs) {
     }
 
     /**
-     * Sets the URL to the current poster image. The poster image shown
-     * in the Chromecast Tech UI view is updated with this new URL.
+     * Sets the URL to the current poster image. The poster image shown in the Chromecast
+     * Tech UI view is updated with this new URL.
      *
      * @param poster {string} the URL to the new poster image
      * @see {@link http://docs.videojs.com/Tech.html#setPoster}
@@ -1559,16 +665,15 @@ module.exports = function (videojs) {
     }
 
     /**
-     * This function is "required" when implementing {@link external:Tech}
-     * and is supposed to return a mock
+     * This function is "required" when implementing {@link external:Tech} and is supposed
+     * to return a mock
      * {@link https://developer.mozilla.org/en-US/docs/Web/API/TimeRanges|TimeRanges}
      * object that represents the portions of the current media item that have been
-     * buffered. However, the Chromecast API does not currently provide a way
-     * to determine how much the media item has buffered, so we always
-     * return `undefined`.
+     * buffered. However, the Chromecast API does not currently provide a way to determine
+     * how much the media item has buffered, so we always return `undefined`.
      *
-     * Returning `undefined` is safe: the player will simply not display
-     * the buffer amount indicator in the scrubber UI.
+     * Returning `undefined` is safe: the player will simply not display the buffer amount
+     * indicator in the scrubber UI.
      *
      * @returns {undefined} always returns `undefined`
      * @see {@link http://docs.videojs.com/Player.html#buffered}
@@ -1578,30 +683,28 @@ module.exports = function (videojs) {
     }
 
     /**
-     * This function is "required" when implementing {@link external:Tech}
-     * and is supposed to return a mock
+     * This function is "required" when implementing {@link external:Tech} and is supposed
+     * to return a mock
      * {@link https://developer.mozilla.org/en-US/docs/Web/API/TimeRanges|TimeRanges}
      * object that represents the portions of the current media item that has playable
-     * content. However, the Chromecast API does not currently provide a
-     * way to determine how much the media item has playable content, so
-     * we'll just assume the entire video is an available seek target.
+     * content. However, the Chromecast API does not currently provide a way to determine
+     * how much the media item has playable content, so we'll just assume the entire video
+     * is an available seek target.
      *
      * The risk here lies with live streaming, where there may exist a sliding window of
-     * playable content and seeking is only possible within the last X number of
-     * minutes, rather than for the entire video.
+     * playable content and seeking is only possible within the last X number of minutes,
+     * rather than for the entire video.
      *
-     * Unfortunately we have no way of detecting when this is the case. Returning
-     * anything other than the full range of the video means that we lose the ability
-     * to seek during VOD.
+     * Unfortunately we have no way of detecting when this is the case. Returning anything
+     * other than the full range of the video means that we lose the ability to seek during
+     * VOD.
      *
-     * @returns {TimeRanges} always returns a `TimeRanges` object with one
-     * `TimeRange` that starts at `0` and ends at the `duration` of the
-     * current media item
+     * @returns {TimeRanges} always returns a `TimeRanges` object with one `TimeRange` that
+     * starts at `0` and ends at the `duration` of the current media item
      * @see {@link http://docs.videojs.com/Player.html#seekable}
      */
     seekable() {
-      // TODO Investigate if there's a way to detect
-      // if the source is live, so that we can
+      // TODO Investigate if there's a way to detect if the source is live, so that we can
       // possibly adjust the seekable `TimeRanges` accordingly.
       return this.videojs.createTimeRange(0, this.duration());
     }
@@ -1618,9 +721,9 @@ module.exports = function (videojs) {
     }
 
     /**
-     * Returns whether or not the browser should show the player
-     * "inline" (non-fullscreen) by default. This function always
-     * returns true to tell the browser that non-fullscreen playback is preferred.
+     * Returns whether or not the browser should show the player "inline" (non-fullscreen)
+     * by default. This function always returns true to tell the browser that non-
+     * fullscreen playback is preferred.
      *
      * @returns {boolean} always returns `true`
      * @see {@link http://docs.videojs.com/Html5.html#playsinline} for an example
@@ -1630,8 +733,8 @@ module.exports = function (videojs) {
     }
 
     /**
-     * Returns whether or not fullscreen is supported by this Tech.
-     * Always returns `true` because fullscreen is always supported.
+     * Returns whether or not fullscreen is supported by this Tech. Always returns `true`
+     * because fullscreen is always supported.
      *
      * @returns {boolean} always returns `true`
      * @see {@link http://docs.videojs.com/Html5.html#supportsFullScreen} for an example
@@ -1676,9 +779,9 @@ module.exports = function (videojs) {
     }
 
     /**
-     * Causes the Tech to begin loading the current source. `load`
-     * is not supported in this ChromecastTech because setting the
-     * source on the `Chromecast` automatically causes it to begin loading.
+     * Causes the Tech to begin loading the current source. `load` is not supported in this
+     * ChromecastTech because setting the source on the `Chromecast` automatically causes
+     * it to begin loading.
      */
     load() {
       // Not supported
@@ -1711,6 +814,23 @@ module.exports = function (videojs) {
 
       this._addEventListener(
         this._remotePlayerController,
+        eventTypes.MEDIA_INFO_CHANGED,
+        () => {
+          if (typeof this._getMediaSession().activeTrackIds[0] === "number") {
+            const id = this._getMediaSession().activeTrackIds[0];
+
+            const tracks = this._getMediaSession().media.tracks;
+
+            const name = tracks[id].name;
+
+            this._onChangeSubtitleTrack({ name });
+          } else {
+            this._onChangeSubtitleTrack(null);
+          }
+        }
+      );
+      this._addEventListener(
+        this._remotePlayerController,
         eventTypes.PLAYER_STATE_CHANGED,
         this._onPlayerStateChanged,
         this
@@ -1739,21 +859,54 @@ module.exports = function (videojs) {
         this._triggerDurationChangeEvent,
         this
       );
+      // If any subtitles were loaded on cast receiver side,
+      // check if they exist on web player side, if not add them
+      this._addEventListener(
+        this._remotePlayerController,
+        eventTypes.MEDIA_INFO_CHANGED,
+        (event) => {
+          this.videojsPlayer.remoteTextTracks();
+          const alreadyLoadedTracks =
+            this.videojsPlayer.remoteTextTracks().tracks_;
+
+          const player = this.videojsPlayer;
+
+          if (event.value && event.value.tracks) {
+            event.value.tracks.forEach(function (track) {
+              const isAlreadyLoaded = alreadyLoadedTracks.some(function (
+                alreadyLoadedTrack
+              ) {
+                return alreadyLoadedTrack.id === track.name;
+              });
+
+              if (!isAlreadyLoaded) {
+                track.id = track.name;
+                player.addRemoteTextTrack(track);
+              }
+            });
+          }
+        }
+      );
+      this._addEventListener(
+        this._remotePlayerController,
+        eventTypes.MEDIA_INFO_CHANGED,
+        this._handleMediaInfoChangeEvent,
+        this
+      );
     }
 
     /**
-     * Registers an event listener on the given target object.
-     * Because many objects in the Chromecast API are either singletons
-     * or must be shared between instances of `ChromecastTech` for the
-     * lifetime of the player, we must unbind the listeners when this Tech
-     * instance is destroyed to prevent memory leaks. To do that, we need to keep
-     * a reference to listeners that are added to global objects so that we can
-     * use those references to remove the listener when this Tech is destroyed.
+     * Registers an event listener on the given target object. Because many objects in the
+     * Chromecast API are either singletons or must be shared between instances of
+     * `ChromecastTech` for the lifetime of the player, we must unbind the listeners when
+     * this Tech instance is destroyed to prevent memory leaks. To do that, we need to keep
+     * a reference to listeners that are added to global objects so that we can use those
+     * references to remove the listener when this Tech is destroyed.
      *
      * @param target {object} the object to register the event listener on
      * @param type {string} the name of the event
-     * @param callback {Function} the listener's callback function that
-     * executes when the event is emitted
+     * @param callback {Function} the listener's callback function that executes when the
+     * event is emitted
      * @param context {object} the `this` context to use when executing the `callback`
      * @private
      */
@@ -1772,9 +925,25 @@ module.exports = function (videojs) {
     }
 
     /**
+     * _onDispose
+     * @private
+     */
+    _onDispose() {
+      var textTrackDisplay = this.videojsPlayer.getChild("TextTrackDisplay");
+
+      if (textTrackDisplay) {
+        textTrackDisplay.show();
+      }
+      clearTimeout(this.playStateValidationTimeout);
+      this._removeAllEventListeners();
+      // even with `stopCasting === false`, `endCurrentSession` *stops* casting
+      // this._getCastContext().endCurrentSession(/* stopCasting */ false);
+    }
+
+    /**
      * Removes all event listeners that were registered with global objects during the
-     * lifetime of this Tech. See {@link _addEventListener} for more information
-     * about why this is necessary.
+     * lifetime of this Tech. See {@link _addEventListener} for more information about why
+     * this is necessary.
      *
      * @private
      */
@@ -1786,9 +955,9 @@ module.exports = function (videojs) {
     }
 
     /**
-     * Removes a single event listener that was registered with global objects
-     * during the lifetime of this Tech. See {@link _addEventListener} for
-     * more information about why this is necessary.
+     * Removes a single event listener that was registered with global objects during the
+     * lifetime of this Tech. See {@link _addEventListener} for more information about why
+     * this is necessary.
      *
      * @private
      */
@@ -1847,11 +1016,11 @@ module.exports = function (videojs) {
     }
 
     /**
-     * Handles Chromecast MediaSession state change events. The only property sent
-     * to this event is whether the session is alive. This is useful for determining
-     * if an item has ended as the MediaSession will fire this event with `false` then
-     * be immediately destroyed. This means that we cannot trust `idleReason` to show
-     * whether an item has ended since we may no longer have access to the MediaSession.
+     * Handles Chromecast MediaSession state change events. The only property sent to this
+     * event is whether the session is alive. This is useful for determining if an item has
+     * ended as the MediaSession will fire this event with `false` then be immediately
+     * destroyed. This means that we cannot trust `idleReason` to show whether an item has
+     * ended since we may no longer have access to the MediaSession.
      *
      * @private
      */
@@ -1864,9 +1033,9 @@ module.exports = function (videojs) {
      *
      * If the Chromecast player is in the "IDLE" state after an item has ended, and no
      * further items are queued up to play, the session is considered inactive. Once a
-     * period of time (currently 10 seconds) has elapsed with no activity, we manually
-     * end the session to prevent long periods of a blank Chromecast screen that is
-     * shown at the end of item playback.
+     * period of time (currently 10 seconds) has elapsed with no activity, we manually end
+     * the session to prevent long periods of a blank Chromecast screen that is shown at
+     * the end of item playback.
      *
      * @private
      */
@@ -1955,6 +1124,13 @@ module.exports = function (videojs) {
     }
 
     /**
+     * @private
+     */
+    _handleMediaInfoChangeEvent(event) {
+      this._requestQueueItemChange(event);
+    }
+
+    /**
      * Triggers an 'error' event
      * @private
      * @see http://docs.videojs.com/Player.html#event:error
@@ -1964,12 +1140,838 @@ module.exports = function (videojs) {
     }
   }
 
+  /**
+   * Registers the ChromecastTech Tech with Video.js. Calls {@link
+   * http://docs.videojs.com/Tech.html#.registerTech}, which will add a Tech called
+   * `chromecast` to the list of globally registered Video.js Tech implementations.
+   *
+   * [Video.js Tech](http://docs.videojs.com/Tech.html) are initialized and used
+   * automatically by Video.js Player instances. Whenever a new source is set on the player,
+   * the player iterates through the list of available Tech to determine which to use to
+   * play the source.
+   *
+   * @param videojs {object} A reference to
+   * {@link http://docs.videojs.com/module-videojs.html|Video.js}
+   * @see http://docs.videojs.com/Tech.html#.registerTech
+   */
+  module.exports = function (videojs) {
+    var Tech = videojs.getComponent("Tech"),
+      SESSION_TIMEOUT = 10 * 1000; // milliseconds
+
+    /**
+     * @module ChomecastTech
+     */
+
+    /**
+     * The Video.js Tech class is the base class for classes that provide media playback
+     * technology implementations to Video.js such as HTML5, Flash and HLS.
+     *
+     * @external Tech
+     * @see {@link http://docs.videojs.com/Tech.html|Tech}
+     */
+
+    /** @lends ChromecastTech.prototype */
+    class ChromecastTech extends Tech {
+      /**
+       * Implements Video.js playback {@link http://docs.videojs.com/tutorial-tech_.html|Tech}
+       * for {@link https://developers.google.com/cast/|Google's Chromecast}.
+       *
+       * @constructs ChromecastTech
+       * @extends external:Tech
+       * @param options {object} The options to use for configuration
+       * @see {@link https://developers.google.com/cast/|Google Cast}
+       */
+      constructor(options) {
+        super(options);
+
+        this.featuresVolumeControl = true;
+        this.featuresPlaybackRate = false;
+        this.movingMediaElementInDOM = false;
+        this.featuresFullscreenResize = true;
+        this.featuresTimeupdateEvents = true;
+        this.featuresProgressEvents = false;
+        // Text tracks are not supported in this version
+        this.featuresNativeTextTracks = false;
+        this.featuresNativeAudioTracks = false;
+        this.featuresNativeVideoTracks = false;
+
+        // Give ChromecastTech class instances a reference to videojs
+        this.videojs = videojs;
+        this._eventListeners = [];
+
+        this.videojsPlayer = this.videojs(options.playerId);
+        this._chromecastSessionManager =
+          this.videojsPlayer.chromecastSessionManager;
+
+        this._ui.updatePoster(this.videojsPlayer.poster());
+
+        this._remotePlayer = this._chromecastSessionManager.getRemotePlayer();
+        this._remotePlayerController =
+          this._chromecastSessionManager.getRemotePlayerController();
+        this._listenToPlayerControllerEvents();
+        this.on("dispose", this._removeAllEventListeners.bind(this));
+
+        this._hasPlayedAnyItem = false;
+        this._requestTitle =
+          options.requestTitleFn ||
+          function () {
+            /* noop */
+          };
+        this._requestSubtitle =
+          options.requestSubtitleFn ||
+          function () {
+            /* noop */
+          };
+        this._requestCustomData =
+          options.requestCustomDataFn ||
+          function () {
+            /* noop */
+          };
+        // See `currentTime` function
+        this._initialStartTime = options.startTime || 0;
+
+        this._playSource(options.source, this._initialStartTime);
+        this.ready(
+          function () {
+            this.setMuted(options.muted);
+          }.bind(this)
+        );
+      }
+
+      /**
+       * Creates a DOMElement that Video.js displays in its player UI while this Tech is
+       * active.
+       *
+       * @returns {DOMElement}
+       * @see {@link http://docs.videojs.com/Tech.html#createEl}
+       */
+      createEl() {
+        // We have to initialize the UI here, because the super.constructor
+        // calls `createEl`, which references `this._ui`.
+        this._ui = this._ui || new ChromecastTechUI();
+
+        return this._ui.getDOMElement();
+      }
+
+      /**
+       * Resumes playback if a media item is paused or restarts an item from
+       * its beginning if the item has played and ended.
+       *
+       * @see {@link http://docs.videojs.com/Player.html#play}
+       */
+      play() {
+        if (!this.paused()) {
+          return;
+        }
+        if (this.ended() && !this._isMediaLoading) {
+          // Restart the current item from the beginning
+          this._playSource({ src: this.videojsPlayer.src() }, 0);
+        } else {
+          this._remotePlayerController.playOrPause();
+        }
+      }
+
+      /**
+       * Pauses playback if the player is not already paused and if the current media item
+       * has not ended yet.
+       *
+       * @see {@link http://docs.videojs.com/Player.html#pause}
+       */
+      pause() {
+        if (!this.paused() && this._remotePlayer.canPause) {
+          this._remotePlayerController.playOrPause();
+        }
+      }
+
+      /**
+       * Returns whether or not the player is "paused". Video.js'
+       * definition of "paused" is "playback paused" OR "not playing".
+       *
+       * @returns {boolean} true if playback is paused
+       * @see {@link http://docs.videojs.com/Player.html#paused}
+       */
+      paused() {
+        return (
+          this._remotePlayer.isPaused ||
+          this.ended() ||
+          this._remotePlayer.playerState === null
+        );
+      }
+
+      /**
+       * Stores the given source and begins playback, starting at the beginning
+       * of the media item.
+       *
+       * @param source {object} the source to store and play
+       * @see {@link http://docs.videojs.com/Player.html#src}
+       */
+      setSource(source) {
+        if (
+          this._currentSource &&
+          this._currentSource.src === source.src &&
+          this._currentSource.type === source.type
+        ) {
+          // Skip setting the source if the `source` argument is the
+          // same as what's already been set. This `setSource` function
+          // calls `this._playSource` which sends a "load media" request
+          // to the Chromecast PlayerController. Because this function
+          // may be called multiple times in rapid succession with the same `source`
+          // argument, we need to de-duplicate calls with the same `source` argument to
+          // prevent overwhelming the Chromecast PlayerController with expensive "load
+          // media" requests, which it itself does not de-duplicate.
+          return;
+        }
+        // We cannot use `this.videojsPlayer.currentSource()` because the
+        // value returned by that function is not the same as what's returned
+        // by the Video.js Player's middleware after they are run. Also, simply
+        // using `this.videojsPlayer.src()` does not include mimetype information
+        // which we pass to the Chromecast player.
+        this._currentSource = source;
+        this._playSource(source, 0);
+      }
+
+      /**
+       * Plays the given source, beginning at an optional starting time.
+       *
+       * @private
+       * @param source {object} the source to play
+       * @param [startTime] The time to start playback at, in seconds
+       * @see {@link http://docs.videojs.com/Player.html#src}
+       */
+      _playSource(source, startTime) {
+        var castSession = this._getCastSession(),
+          mediaInfo = new chrome.cast.media.MediaInfo(source.src, source.type),
+          title = this._requestTitle(source),
+          subtitle = this._requestSubtitle(source),
+          poster = this.poster(),
+          customData = this._requestCustomData(source),
+          request;
+
+        this.trigger("waiting");
+        this._clearSessionTimeout();
+
+        mediaInfo.metadata = new chrome.cast.media.GenericMediaMetadata();
+        mediaInfo.metadata.metadataType =
+          chrome.cast.media.MetadataType.GENERIC;
+        mediaInfo.metadata.title = title;
+        mediaInfo.metadata.subtitle = subtitle;
+        mediaInfo.streamType =
+          this.videojsPlayer.liveTracker &&
+          this.videojsPlayer.liveTracker.isLive()
+            ? chrome.cast.media.StreamType.LIVE
+            : chrome.cast.media.StreamType.BUFFERED;
+
+        if (poster) {
+          mediaInfo.metadata.images = [{ url: poster }];
+        }
+        if (customData) {
+          mediaInfo.customData = customData;
+        }
+
+        this._ui.updateTitle(title);
+        this._ui.updateSubtitle(subtitle);
+
+        request = new chrome.cast.media.LoadRequest(mediaInfo);
+        request.autoplay = true;
+        request.currentTime = startTime;
+
+        this._isMediaLoading = true;
+        this._hasPlayedCurrentItem = false;
+        castSession.loadMedia(request).then(
+          function () {
+            if (!this._hasPlayedAnyItem) {
+              // `triggerReady` is required here to notify the Video.js
+              // player that the Tech has been initialized and is ready.
+              this.triggerReady();
+            }
+            this.trigger("loadstart");
+            this.trigger("loadeddata");
+            this.trigger("play");
+            this.trigger("playing");
+            this._hasPlayedAnyItem = true;
+            this._isMediaLoading = false;
+            this._getMediaSession().addUpdateListener(
+              this._onMediaSessionStatusChanged.bind(this)
+            );
+          }.bind(this),
+          this._triggerErrorEvent.bind(this)
+        );
+      }
+
+      /**
+       * Manually updates the current time. The playback position will jump to
+       * the given time and continue playing if the item was playing when `setCurrentTime`
+       * was called, or remain paused if the item was paused.
+       *
+       * @param time {number} the playback time position to jump to
+       * @see {@link http://docs.videojs.com/Tech.html#setCurrentTime}
+       */
+      setCurrentTime(time) {
+        var duration = this.duration();
+
+        if (time > duration || !this._remotePlayer.canSeek) {
+          return;
+        }
+        // Seeking to any place within (approximately) 1 second of the end of the item
+        // causes the Video.js player to get stuck in a BUFFERING state. To work around
+        // this, we only allow seeking to within 1 second of the end of an item.
+        this._remotePlayer.currentTime = Math.min(duration - 1, time);
+        this._remotePlayerController.seek();
+        this._triggerTimeUpdateEvent();
+      }
+
+      /**
+       * Returns the current playback time position.
+       *
+       * @returns {number} the current playback time position
+       * @see {@link http://docs.videojs.com/Player.html#currentTime}
+       */
+      currentTime() {
+        // There is a brief period of time when Video.js has switched to the chromecast
+        // Tech, but chromecast has not yet loaded its first media item. During
+        // that time, Video.js calls this `currentTime` function to update
+        // its player UI. In that period, `this._remotePlayer.currentTime`
+        // will be 0 because the media has not loaded yet. To prevent the
+        // UI from using a 0 second currentTime, we use the currentTime passed
+        // in to the first media item that was provided to the Tech until
+        // chromecast plays its first item.
+        if (!this._hasPlayedAnyItem) {
+          return this._initialStartTime;
+        }
+        return this._remotePlayer.currentTime;
+      }
+
+      /**
+       * Returns the duration of the current media item, or `0` if the source
+       * is not set or if the duration of the item is not available from the
+       * Chromecast API yet.
+       *
+       * @returns {number} the duration of the current media item
+       * @see {@link http://docs.videojs.com/Player.html#duration}
+       */
+      duration() {
+        // There is a brief period of time when Video.js has switched to the chromecast
+        // Tech, but chromecast has not yet loaded its first media item.
+        // During that time, Video.js calls this `duration` function to update its player
+        // UI. In that period, `this._remotePlayer.duration` will be 0 because the media
+        // has not loaded yet. To prevent the UI from using a 0 second duration, we
+        // use the duration passed in to the first media item that was provided to
+        // the Tech until chromecast plays its first item.
+        if (!this._hasPlayedAnyItem) {
+          return this.videojsPlayer.duration();
+        }
+        return this._remotePlayer.duration;
+      }
+
+      /**
+       * Returns whether or not the current media item has finished playing.
+       * Returns `false` if a media item has not been loaded, has not been played,
+       * or has not yet finished playing.
+       *
+       * @returns {boolean} true if the current media item has finished playing
+       * @see {@link http://docs.videojs.com/Player.html#ended}
+       */
+      ended() {
+        var mediaSession = this._getMediaSession();
+
+        if (!mediaSession && this._hasMediaSessionEnded) {
+          return true;
+        }
+
+        return mediaSession
+          ? mediaSession.idleReason === chrome.cast.media.IdleReason.FINISHED
+          : false;
+      }
+
+      /**
+       * Returns the current volume level setting as a decimal number between `0` and `1`.
+       *
+       * @returns {number} the current volume level
+       * @see {@link http://docs.videojs.com/Player.html#volume}
+       */
+      volume() {
+        return this._remotePlayer.volumeLevel;
+      }
+
+      /**
+       * Sets the current volume level. Volume level is a decimal number
+       * between `0` and `1`, where `0` is muted and `1` is the loudest volume level.
+       *
+       * @param volumeLevel {number}
+       * @returns {number} the current volume level
+       * @see {@link http://docs.videojs.com/Player.html#volume}
+       */
+      setVolume(volumeLevel) {
+        this._remotePlayer.volumeLevel = volumeLevel;
+        this._remotePlayerController.setVolumeLevel();
+        // This event is triggered by the listener on
+        // `RemotePlayerEventType.VOLUME_LEVEL_CHANGED`, but waiting for
+        // that event to fire in response to calls to `setVolume` introduces
+        // noticeable lag in the updating of the player UI's volume slider bar,
+        // which makes user interaction with the volume slider choppy.
+        this._triggerVolumeChangeEvent();
+      }
+
+      /**
+       * Returns whether or not the player is currently muted.
+       *
+       * @returns {boolean} true if the player is currently muted
+       * @see {@link http://docs.videojs.com/Player.html#muted}
+       */
+      muted() {
+        return this._remotePlayer.isMuted;
+      }
+
+      /**
+       * Mutes or un-mutes the player. Does nothing if the player is currently
+       * muted and the `isMuted` parameter is true or if the player is not muted and
+       * `isMuted` is false.
+       *
+       * @param isMuted {boolean} whether or not the player should be muted
+       * @see {@link http://docs.videojs.com/Html5.html#setMuted} for an example
+       */
+      setMuted(isMuted) {
+        if (
+          (this._remotePlayer.isMuted && !isMuted) ||
+          (!this._remotePlayer.isMuted && isMuted)
+        ) {
+          this._remotePlayerController.muteOrUnmute();
+        }
+      }
+
+      /**
+       * Gets the URL to the current poster image.
+       *
+       * @returns {string} URL to the current poster image or `undefined` if none exists
+       * @see {@link http://docs.videojs.com/Player.html#poster}
+       */
+      poster() {
+        return this._ui.getPoster();
+      }
+
+      /**
+       * Sets the URL to the current poster image. The poster image shown
+       * in the Chromecast Tech UI view is updated with this new URL.
+       *
+       * @param poster {string} the URL to the new poster image
+       * @see {@link http://docs.videojs.com/Tech.html#setPoster}
+       */
+      setPoster(poster) {
+        this._ui.updatePoster(poster);
+      }
+
+      /**
+       * This function is "required" when implementing {@link external:Tech}
+       * and is supposed to return a mock
+       * {@link https://developer.mozilla.org/en-US/docs/Web/API/TimeRanges|TimeRanges}
+       * object that represents the portions of the current media item that have been
+       * buffered. However, the Chromecast API does not currently provide a way
+       * to determine how much the media item has buffered, so we always
+       * return `undefined`.
+       *
+       * Returning `undefined` is safe: the player will simply not display
+       * the buffer amount indicator in the scrubber UI.
+       *
+       * @returns {undefined} always returns `undefined`
+       * @see {@link http://docs.videojs.com/Player.html#buffered}
+       */
+      buffered() {
+        return undefined;
+      }
+
+      /**
+       * This function is "required" when implementing {@link external:Tech}
+       * and is supposed to return a mock
+       * {@link https://developer.mozilla.org/en-US/docs/Web/API/TimeRanges|TimeRanges}
+       * object that represents the portions of the current media item that has playable
+       * content. However, the Chromecast API does not currently provide a
+       * way to determine how much the media item has playable content, so
+       * we'll just assume the entire video is an available seek target.
+       *
+       * The risk here lies with live streaming, where there may exist a sliding window of
+       * playable content and seeking is only possible within the last X number of
+       * minutes, rather than for the entire video.
+       *
+       * Unfortunately we have no way of detecting when this is the case. Returning
+       * anything other than the full range of the video means that we lose the ability
+       * to seek during VOD.
+       *
+       * @returns {TimeRanges} always returns a `TimeRanges` object with one
+       * `TimeRange` that starts at `0` and ends at the `duration` of the
+       * current media item
+       * @see {@link http://docs.videojs.com/Player.html#seekable}
+       */
+      seekable() {
+        // TODO Investigate if there's a way to detect
+        // if the source is live, so that we can
+        // possibly adjust the seekable `TimeRanges` accordingly.
+        return this.videojs.createTimeRange(0, this.duration());
+      }
+
+      /**
+       * Returns whether the native media controls should be shown (`true`) or hidden
+       * (`false`). Not applicable to this Tech.
+       *
+       * @returns {boolean} always returns `false`
+       * @see {@link http://docs.videojs.com/Html5.html#controls} for an example
+       */
+      controls() {
+        return false;
+      }
+
+      /**
+       * Returns whether or not the browser should show the player
+       * "inline" (non-fullscreen) by default. This function always
+       * returns true to tell the browser that non-fullscreen playback is preferred.
+       *
+       * @returns {boolean} always returns `true`
+       * @see {@link http://docs.videojs.com/Html5.html#playsinline} for an example
+       */
+      playsinline() {
+        return true;
+      }
+
+      /**
+       * Returns whether or not fullscreen is supported by this Tech.
+       * Always returns `true` because fullscreen is always supported.
+       *
+       * @returns {boolean} always returns `true`
+       * @see {@link http://docs.videojs.com/Html5.html#supportsFullScreen} for an example
+       */
+      supportsFullScreen() {
+        return true;
+      }
+
+      /**
+       * Sets a flag that determines whether or not the media should automatically begin
+       * playing on page load. This is not supported because a Chromecast session must be
+       * initiated by casting via the casting menu and cannot autoplay.
+       *
+       * @see {@link http://docs.videojs.com/Html5.html#setAutoplay} for an example
+       */
+      setAutoplay() {
+        // Not supported
+      }
+
+      /**
+       * @returns {number} the chromecast player's playback rate, if available. Otherwise,
+       * the return value defaults to `1`.
+       */
+      playbackRate() {
+        var mediaSession = this._getMediaSession();
+
+        return mediaSession ? mediaSession.playbackRate : 1;
+      }
+
+      /**
+       * Does nothing. Changing the playback rate is not supported.
+       */
+      setPlaybackRate() {
+        // Not supported
+      }
+
+      /**
+       * Does nothing. Satisfies calls to the missing preload method.
+       */
+      preload() {
+        // Not supported
+      }
+
+      /**
+       * Causes the Tech to begin loading the current source. `load`
+       * is not supported in this ChromecastTech because setting the
+       * source on the `Chromecast` automatically causes it to begin loading.
+       */
+      load() {
+        // Not supported
+      }
+
+      /**
+       * Gets the Chromecast equivalent of HTML5 Media Element's `readyState`.
+       *
+       * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/readyState
+       */
+      readyState() {
+        if (
+          this._remotePlayer.playerState === "IDLE" ||
+          this._remotePlayer.playerState === "BUFFERING"
+        ) {
+          return 0; // HAVE_NOTHING
+        }
+        return 4;
+      }
+
+      /**
+       * Wires up event listeners for
+       * [RemotePlayerController](https://developers.google.com/cast/docs/reference/chrome/cast.framework.RemotePlayerController)
+       * events.
+       *
+       * @private
+       */
+      _listenToPlayerControllerEvents() {
+        var eventTypes = cast.framework.RemotePlayerEventType;
+
+        this._addEventListener(
+          this._remotePlayerController,
+          eventTypes.PLAYER_STATE_CHANGED,
+          this._onPlayerStateChanged,
+          this
+        );
+        this._addEventListener(
+          this._remotePlayerController,
+          eventTypes.VOLUME_LEVEL_CHANGED,
+          this._triggerVolumeChangeEvent,
+          this
+        );
+        this._addEventListener(
+          this._remotePlayerController,
+          eventTypes.IS_MUTED_CHANGED,
+          this._triggerVolumeChangeEvent,
+          this
+        );
+        this._addEventListener(
+          this._remotePlayerController,
+          eventTypes.CURRENT_TIME_CHANGED,
+          this._triggerTimeUpdateEvent,
+          this
+        );
+        this._addEventListener(
+          this._remotePlayerController,
+          eventTypes.DURATION_CHANGED,
+          this._triggerDurationChangeEvent,
+          this
+        );
+      }
+
+      /**
+       * Registers an event listener on the given target object.
+       * Because many objects in the Chromecast API are either singletons
+       * or must be shared between instances of `ChromecastTech` for the
+       * lifetime of the player, we must unbind the listeners when this Tech
+       * instance is destroyed to prevent memory leaks. To do that, we need to keep
+       * a reference to listeners that are added to global objects so that we can
+       * use those references to remove the listener when this Tech is destroyed.
+       *
+       * @param target {object} the object to register the event listener on
+       * @param type {string} the name of the event
+       * @param callback {Function} the listener's callback function that
+       * executes when the event is emitted
+       * @param context {object} the `this` context to use when executing the `callback`
+       * @private
+       */
+      _addEventListener(target, type, callback, context) {
+        var listener;
+
+        listener = {
+          target: target,
+          type: type,
+          callback: callback,
+          context: context,
+          listener: callback.bind(context),
+        };
+        target.addEventListener(type, listener.listener);
+        this._eventListeners.push(listener);
+      }
+
+      /**
+       * Removes all event listeners that were registered with global objects during the
+       * lifetime of this Tech. See {@link _addEventListener} for more information
+       * about why this is necessary.
+       *
+       * @private
+       */
+      _removeAllEventListeners() {
+        while (this._eventListeners.length > 0) {
+          this._removeEventListener(this._eventListeners[0]);
+        }
+        this._eventListeners = [];
+      }
+
+      /**
+       * Removes a single event listener that was registered with global objects
+       * during the lifetime of this Tech. See {@link _addEventListener} for
+       * more information about why this is necessary.
+       *
+       * @private
+       */
+      _removeEventListener(listener) {
+        var index = -1,
+          pass = false,
+          i;
+
+        listener.target.removeEventListener(listener.type, listener.listener);
+
+        for (i = 0; i < this._eventListeners.length; i++) {
+          pass =
+            this._eventListeners[i].target === listener.target &&
+            this._eventListeners[i].type === listener.type &&
+            this._eventListeners[i].callback === listener.callback &&
+            this._eventListeners[i].context === listener.context;
+
+          if (pass) {
+            index = i;
+            break;
+          }
+        }
+
+        if (index !== -1) {
+          this._eventListeners.splice(index, 1);
+        }
+      }
+
+      /**
+       * Handles Chromecast player state change events. The player may "change state" when
+       * paused, played, buffering, etc.
+       *
+       * @private
+       */
+      _onPlayerStateChanged() {
+        var states = chrome.cast.media.PlayerState,
+          playerState = this._remotePlayer.playerState;
+
+        if (playerState === states.PLAYING) {
+          this._hasPlayedCurrentItem = true;
+          this.trigger("play");
+          this.trigger("playing");
+        } else if (playerState === states.PAUSED) {
+          this.trigger("pause");
+        } else if (
+          (playerState === states.IDLE && this.ended()) ||
+          (playerState === null && this._hasPlayedCurrentItem)
+        ) {
+          this._hasPlayedCurrentItem = false;
+          this._closeSessionOnTimeout();
+          this.trigger("ended");
+          this._triggerTimeUpdateEvent();
+        } else if (playerState === states.BUFFERING) {
+          this.trigger("waiting");
+        }
+      }
+
+      /**
+       * Handles Chromecast MediaSession state change events. The only property sent
+       * to this event is whether the session is alive. This is useful for determining
+       * if an item has ended as the MediaSession will fire this event with `false` then
+       * be immediately destroyed. This means that we cannot trust `idleReason` to show
+       * whether an item has ended since we may no longer have access to the MediaSession.
+       *
+       * @private
+       */
+      _onMediaSessionStatusChanged(isAlive) {
+        this._hasMediaSessionEnded = !!isAlive;
+      }
+
+      /**
+       * Ends the session after a certain number of seconds of inactivity.
+       *
+       * If the Chromecast player is in the "IDLE" state after an item has ended, and no
+       * further items are queued up to play, the session is considered inactive. Once a
+       * period of time (currently 10 seconds) has elapsed with no activity, we manually
+       * end the session to prevent long periods of a blank Chromecast screen that is
+       * shown at the end of item playback.
+       *
+       * @private
+       */
+      _closeSessionOnTimeout() {
+        // Ensure that there's never more than one session timeout active
+        this._clearSessionTimeout();
+        this._sessionTimeoutID = setTimeout(
+          function () {
+            var castSession = this._getCastSession();
+
+            if (castSession) {
+              castSession.endSession(true);
+            }
+            this._clearSessionTimeout();
+          }.bind(this),
+          SESSION_TIMEOUT
+        );
+      }
+
+      /**
+       * Stops the timeout that is waiting during a period of inactivity in order to close
+       * the session.
+       *
+       * @private
+       * @see _closeSessionOnTimeout
+       */
+      _clearSessionTimeout() {
+        if (this._sessionTimeoutID) {
+          clearTimeout(this._sessionTimeoutID);
+          this._sessionTimeoutID = false;
+        }
+      }
+
+      /**
+       * @private
+       * @return {object} the current CastContext, if one exists
+       */
+      _getCastContext() {
+        return this._chromecastSessionManager.getCastContext();
+      }
+
+      /**
+       * @private
+       * @return {object} the current CastSession, if one exists
+       */
+      _getCastSession() {
+        return this._getCastContext().getCurrentSession();
+      }
+
+      /**
+       * @private
+       * @return {object} the current MediaSession, if one exists
+       * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.Media
+       */
+      _getMediaSession() {
+        var castSession = this._getCastSession();
+
+        return castSession ? castSession.getMediaSession() : null;
+      }
+
+      /**
+       * Triggers a 'volumechange' event
+       * @private
+       * @see http://docs.videojs.com/Player.html#event:volumechange
+       */
+      _triggerVolumeChangeEvent() {
+        this.trigger("volumechange");
+      }
+
+      /**
+       * Triggers a 'timeupdate' event
+       * @private
+       * @see http://docs.videojs.com/Player.html#event:timeupdate
+       */
+      _triggerTimeUpdateEvent() {
+        this.trigger("timeupdate");
+      }
+
+      /**
+       * Triggers a 'durationchange' event
+       * @private
+       * @see http://docs.videojs.com/Player.html#event:durationchange
+       */
+      _triggerDurationChangeEvent() {
+        this.trigger("durationchange");
+      }
+
+      /**
+       * Triggers an 'error' event
+       * @private
+       * @see http://docs.videojs.com/Player.html#event:error
+       */
+      _triggerErrorEvent() {
+        this.trigger("error");
+      }
+    }
+  };
+
   // Required for Video.js Tech implementations.
   // TODO Consider a more comprehensive check based on mimetype.
   ChromecastTech.canPlaySource = () => {
     return ChromecastSessionManager.isChromecastConnected();
   };
-
 
   videojs.registerTech("chromecast", ChromecastTech);
 };

--- a/tests/ChromcastButton.test.js
+++ b/tests/ChromcastButton.test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var expect = require('expect.js');
+
+const chromecastButton = require('../src/js/components/ChromecastButton');
+
+class ButtonComponentStub {}
+
+describe('ChromecastButton', function() {
+   it('should not call videojs.extend', function() {
+      const videoJsSpy = {
+         extend: function() {
+            expect().fail('videojs.extends is deprecated');
+         },
+         getComponent: function() {
+            return ButtonComponentStub;
+         },
+         registerComponent: function(_, component) {
+            expect(component.prototype instanceof ButtonComponentStub).to.be(true);
+         },
+      };
+
+      chromecastButton(videoJsSpy);
+   });
+});

--- a/tests/ChromcastButton.test.js
+++ b/tests/ChromcastButton.test.js
@@ -10,7 +10,7 @@ describe('ChromecastButton', function() {
    it('should not call videojs.extend', function() {
       const videoJsSpy = {
          extend: function() {
-            expect().fail('videojs.extends is deprecated');
+            expect().fail('videojs.extend is deprecated');
          },
          getComponent: function() {
             return ButtonComponentStub;

--- a/tests/ChromcastTech.test.js
+++ b/tests/ChromcastTech.test.js
@@ -11,7 +11,7 @@ describe('ChromecastTech', function() {
    it('should not call videojs.extend', function() {
       const videoJsSpy = {
          extend: function() {
-            expect().fail('videojs.extends is deprecated');
+            expect().fail('videojs.extend is deprecated');
          },
          getComponent: function() {
             return TechComponentStub;

--- a/tests/ChromcastTech.test.js
+++ b/tests/ChromcastTech.test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var expect = require('expect.js');
+
+const chromecastTech = require('../src/js/tech/ChromecastTech');
+
+class TechComponentStub {
+}
+
+describe('ChromecastTech', function() {
+   it('should not call videojs.extend', function() {
+      const videoJsSpy = {
+         extend: function() {
+            expect().fail('videojs.extends is deprecated');
+         },
+         getComponent: function() {
+            return TechComponentStub;
+         },
+         registerTech: function(_, component) {
+            expect(component.prototype instanceof TechComponentStub).to.be(true);
+         },
+      };
+
+      chromecastTech(videoJsSpy);
+   });
+});


### PR DESCRIPTION
The deprecated `.extend` method should not be called when the modules are imported.  The change in the next commit will allow users of the library to upgrade to video.js version 8 where the `.extend` method has been removed.

Issue silvermine#152